### PR TITLE
fix: refactor objectMove to shift instead of swap items

### DIFF
--- a/hooks/useSortable.ts
+++ b/hooks/useSortable.ts
@@ -29,8 +29,7 @@ export function clamp(value: number, lowerBound: number, upperBound: number) {
 export function objectMove(
   object: { [id: string]: number },
   from: number,
-  to: number,
-  clampUpper: number
+  to: number
 ) {
   "worklet";
   const newObject = Object.assign({}, object);
@@ -42,12 +41,13 @@ export function objectMove(
       continue;
     }
 
-    // Items in-between from and to should shift by 1 position
+    // Items in-between from and to should shift by 1 position;
+    // clamping isn't necessary as long as to and from are valid
     const currentPosition = object[id];
     if (movedUp && currentPosition >= to && currentPosition < from) {
-      newObject[id] = clamp(currentPosition + 1, 0, clampUpper);
+      newObject[id]++;
     } else if (currentPosition <= to && currentPosition > from) {
-      newObject[id] = clamp(currentPosition - 1, 0, clampUpper);
+      newObject[id]--;
     }
   }
 
@@ -73,15 +73,17 @@ export function setPosition(
   itemHeight: number
 ) {
   "worklet";
-  const clampUpper = itemsCount - 1;
-  const newPosition = clamp(Math.floor(positionY / itemHeight), 0, clampUpper);
+  const newPosition = clamp(
+    Math.floor(positionY / itemHeight),
+    0,
+    itemsCount - 1
+  );
 
   if (newPosition !== positions.value[id]) {
     positions.value = objectMove(
       positions.value,
       positions.value[id],
-      newPosition,
-      clampUpper
+      newPosition
     );
   }
 }


### PR DESCRIPTION
## Description

When testing SortableExample in the emulators, I noticed that if a drag were done very quickly, items would end up out of order. I traced this to the logic used in the `objectMove` function in `useSortable`, which was swapping the to and from positions; when an item's Y position changes so quickly that its new calculated position is more than one index from its old position, this will not result in the correct order.

I refactored this to shift intervening items up or down as appropriate.

A video of the issue (names changed to id to make the order more clear):

![sortable-bug-demo](https://github.com/user-attachments/assets/b4c580a4-3462-4085-8aac-e123044c04f6)

I'm quickly dragging item 7 upward. All other items should maintain their existing order, yet at the end of the drag, 2 is now above 1.

The logs during the drag show what occurs:

```
 LOG  Item 7 dragged from 6
 LOG  Item 7 dragging over null at 415
 LOG  Item 6 moved from 5 to 6
 LOG  Item 5 moved from 4 to 5
 LOG  Item 4 moved from 3 to 4
 LOG  Item 7 dragging over null at 144
 LOG  Item 3 moved from 2 to 3
 LOG  Item 1 moved from 0 to 2   <-- This indicates the dragged item and item 1 swapped places here,
                                                               altering the order of items 1 and 2.
 LOG  Item 7 dragging over null at -66
 LOG  Item 7 dragging over null at -82
 LOG  Item 7 dragging over null at -85
 LOG  Item 7 dropped at 0
```

The issue may not be apparent in all environments, and likely depends on the rate at which `setPosition()` is called during a drag. However, I think the logic should probably correctly handle the case where the new calculated position is not adjacent to the previous position.

## Type of Change

Bug fix

## Testing

Tested on iOS and Android emulators.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings