### PR TITLE
fix: resolve circular import between Droppable and useDroppable

### DIFF
--- a/components/Droppable.tsx
+++ b/components/Droppable.tsx
@@ -5,11 +5,6 @@ import Animated from "react-native-reanimated";
 import { useDroppable } from "../hooks/useDroppable";
 import { UseDroppableOptions, DroppableProps } from "../types/droppable";
 
-let _nextDroppableId = 1;
-export const _getUniqueDroppableId = (): number => {
-  return _nextDroppableId++;
-};
-
 /**
  * A component that creates drop zones for receiving draggable items.
  *

--- a/hooks/useDroppable.ts
+++ b/hooks/useDroppable.ts
@@ -18,8 +18,12 @@ import {
   DropAlignment,
   DropOffset,
 } from "../types/context";
-import { _getUniqueDroppableId } from "../components/Droppable";
 import { UseDroppableOptions, UseDroppableReturn } from "../types/droppable";
+
+let _nextDroppableId = 1;
+const _getUniqueDroppableId = (): number => {
+  return _nextDroppableId++;
+};
 
 /**
  * A hook for creating drop zones that can receive draggable items.


### PR DESCRIPTION
- Move _getUniqueDroppableId generator from Droppable component into useDroppable hook
- Fixes 'TypeError: _getUniqueDroppableId is not a function' runtime error (Occurred only if the React compiler is enabled)