### PR TITLE
Add `isDragging` to the context and `draggingStyle` to Droppables

### DIFF
--- a/components/Droppable.tsx
+++ b/components/Droppable.tsx
@@ -277,6 +277,7 @@ export const Droppable = <TData = unknown,>({
   dropAlignment,
   dropOffset,
   activeStyle,
+  draggingStyle,
   droppableId,
   capacity,
   style,
@@ -289,6 +290,7 @@ export const Droppable = <TData = unknown,>({
     dropAlignment,
     dropOffset,
     activeStyle,
+    draggingStyle,
     droppableId,
     capacity,
   });

--- a/context/DropContext.tsx
+++ b/context/DropContext.tsx
@@ -152,6 +152,7 @@ export const DropProvider = forwardRef<DropProviderRef, DropProviderProps>(
     const [activeHoverSlotId, setActiveHoverSlotIdState] = useState<
       number | null
     >(null);
+    const [isDragging, setIsDragging] = useState<boolean>(false);
 
     // New state for tracking dropped items
     const [droppedItems, setDroppedItems] = useState<DroppedItemsMap>({});
@@ -247,12 +248,24 @@ export const DropProvider = forwardRef<DropProviderRef, DropProviderProps>(
     // Create a wrapper for onDragStart that also triggers position update
     const handleDragStart = useCallback(
       (data: any) => {
+        setIsDragging(true);
         if (onDragStart) {
           onDragStart(data);
         }
         internalRequestPositionUpdate();
       },
-      [onDragStart, internalRequestPositionUpdate]
+      [onDragStart, internalRequestPositionUpdate, setIsDragging]
+    );
+
+    const handleDragEnd = useCallback(
+      (data: any) => {
+        setIsDragging(false);
+        if (onDragEnd) {
+          onDragEnd(data);
+        }
+        internalRequestPositionUpdate();
+      },
+      [onDragEnd, internalRequestPositionUpdate, setIsDragging]
     );
 
     // Update the context value with the new method
@@ -278,9 +291,10 @@ export const DropProvider = forwardRef<DropProviderRef, DropProviderProps>(
         unregisterDroppedItem,
         getDroppedItems,
         hasAvailableCapacity,
+        isDragging,
         onDragging,
         onDragStart: handleDragStart,
-        onDragEnd,
+        onDragEnd: handleDragEnd,
       }),
       [
         activeHoverSlotId,
@@ -291,9 +305,11 @@ export const DropProvider = forwardRef<DropProviderRef, DropProviderProps>(
         unregisterDroppedItem,
         getDroppedItems,
         hasAvailableCapacity,
+        isDragging,
         onDragging,
         handleDragStart,
         onDragEnd,
+        handleDragEnd,
       ]
     );
 

--- a/hooks/useDroppable.ts
+++ b/hooks/useDroppable.ts
@@ -158,6 +158,7 @@ export const useDroppable = <TData = unknown>(
     dropAlignment,
     dropOffset,
     activeStyle,
+    draggingStyle,
     droppableId,
     capacity,
   } = options;
@@ -176,6 +177,7 @@ export const useDroppable = <TData = unknown>(
     unregister,
     isRegistered,
     activeHoverSlotId: contextActiveHoverSlotId,
+    isDragging,
     registerPositionUpdateListener,
     unregisterPositionUpdateListener,
   } = useContext(SlotsContext) as SlotsContextValue<TData>;
@@ -208,23 +210,73 @@ export const useDroppable = <TData = unknown>(
     };
   }, [isActive, activeStyle]);
 
+  // Process dragging style to separate transforms from other styles
+  const { processedDraggingStyle, draggingTransforms } = useMemo(() => {
+    if (!isDragging || !draggingStyle) {
+      return { processedDraggingStyle: null, draggingTransforms: [] };
+    }
+
+    const flattenedStyle = StyleSheet.flatten(draggingStyle);
+    let processedStyle = { ...flattenedStyle };
+    let transforms: any[] = [];
+
+    // Extract and process transforms if present
+    if (flattenedStyle.transform) {
+      if (Array.isArray(flattenedStyle.transform)) {
+        transforms = [...flattenedStyle.transform];
+      }
+
+      // Remove transform from the main style to avoid conflicts
+      delete processedStyle.transform;
+    }
+
+    return {
+      processedDraggingStyle: processedStyle,
+      draggingTransforms: transforms,
+    };
+  }, [isDragging, draggingStyle]);
+
   // Create the final style with transforms properly handled
   const combinedActiveStyle = useMemo(() => {
-    if (!isActive || !activeStyle) {
+    if ((!isActive || !activeStyle) && (!isDragging || !draggingStyle)) {
       return undefined;
     }
 
+    let currentStyle = [];
+    let currentTransforms = [];
+
+    if (isDragging && draggingStyle) {
+      currentStyle.push(processedDraggingStyle);
+      currentTransforms = [...currentTransforms, ...draggingTransforms];
+    }
+
+    if (isActive && activeStyle) {
+      currentStyle.push(processedActiveStyle);
+      currentTransforms = [...currentTransforms, ...activeTransforms];
+    }
+
+    const aggregateStyle = StyleSheet.flatten(currentStyle);
+
     // If there are no transforms, just return the processed style
-    if (activeTransforms.length === 0) {
-      return processedActiveStyle;
+    if (currentTransforms.length === 0) {
+      return aggregateStyle;
     }
 
     // Add transforms to the style
     return {
-      ...processedActiveStyle,
-      transform: activeTransforms,
+      ...aggregateStyle,
+      transform: currentTransforms,
     };
-  }, [isActive, activeStyle, processedActiveStyle, activeTransforms]);
+  }, [
+    isActive,
+    activeStyle,
+    processedActiveStyle,
+    activeTransforms,
+    isDragging,
+    draggingStyle,
+    processedDraggingStyle,
+    draggingTransforms,
+  ]);
 
   useEffect(() => {
     onActiveChange?.(isActive);
@@ -320,6 +372,7 @@ export const useDroppable = <TData = unknown>(
       style: combinedActiveStyle,
     },
     isActive,
+    isDragging,
     activeStyle,
     animatedViewRef,
   };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "minify": "node scripts/build.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md,yml,yaml}\" --ignore-path .prettierignore",
-    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md,yml,yaml}\" --ignore-path .prettierignore"
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md,yml,yaml}\" --ignore-path .prettierignore",
+    "prepare": "npm run build"
   },
   "keywords": [
     "react-native",

--- a/types/context.ts
+++ b/types/context.ts
@@ -115,6 +115,8 @@ export interface SlotsContextValue<TData = unknown> {
   // Add new method to check if a droppable has available capacity
   hasAvailableCapacity: (droppableId: string) => boolean;
 
+  isDragging: boolean;
+
   // Add onDragging callback
   onDragging?: (payload: {
     x: number;
@@ -218,6 +220,7 @@ const defaultSlotsContextValue: SlotsContextValue<any> = {
     }
     return false;
   },
+  isDragging: false,
   onDragging: (payload: {
     x: number;
     y: number;

--- a/types/droppable.ts
+++ b/types/droppable.ts
@@ -128,6 +128,27 @@ export interface UseDroppableOptions<TData = unknown> {
   activeStyle?: StyleProp<ViewStyle>;
 
   /**
+   * Style to apply when a draggable item has started to move.
+   * This provides visual feedback to users about valid drop targets.
+   *
+   * @example
+   * ```typescript
+   * const draggingStyle = {
+   *   backgroundColor: 'rgba(0, 255, 0, 0.2)',
+   *   borderColor: '#00ff00',
+   *   borderWidth: 2,
+   *   transform: [{ scale: 1.05 }]
+   * };
+   *
+   * const { viewProps } = useDroppable({
+   *   onDrop: handleDrop,
+   *   draggingStyle
+   * });
+   * ```
+   */
+  draggingStyle?: StyleProp<ViewStyle>;
+
+  /**
    * Unique identifier for this droppable. If not provided, one will be generated automatically.
    * Used for tracking which droppable items are dropped on.
    *
@@ -185,6 +206,12 @@ export interface UseDroppableReturn {
    * Useful for conditional rendering or additional visual feedback.
    */
   isActive: boolean;
+
+  /**
+   * Whether a draggable item is currently moving anywhere on the view.
+   * Useful for conditional rendering or additional visual feedback.
+   */
+  isDragging: boolean;
 
   /**
    * The active style that was passed in options. Useful for external styling logic.


### PR DESCRIPTION
## Description
This PR adds the attribute `isDragging` to the SlotsContext that indicates if an draggable element is currently being dragged anywhere in the context. It also adds the first concrete use case for this attribute, which is enabling different styling on `Droppable` when an element is being dragged, regardless of where it is on screen. This allows more visual feedback by not only highlighting when a dragged item is over a droppable, but allows highlighting where on the screen a dragged item can be dropped at all.

I have tested this on my own project, where I use both the active style to highlight the specific Droppable the dragged item is currently over, but also highlight all other available Droppables. The active style will override the dragging style.

(To be able to test this in my own project, I had to incidentally add the `prepare` script in `package.json` to be able to install the library from github. Can remove that if this is otherwise good to merge, or could move that into its own PR if you want it in general.)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [X] Tested on iOS
- [ ] Tested on Android
- [ ] Added/updated tests
- [X] All existing tests pass


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes