### PR TITLE
Fix: Crash in measure() with Reanimated v4/RN 0.81/Expo 54

### DIFF
--- a/hooks/safeMeasure.ts
+++ b/hooks/safeMeasure.ts
@@ -1,0 +1,25 @@
+import { Component } from 'react';
+import { AnimatedRef, measure } from 'react-native-reanimated';
+
+/**
+ * Worklet-safe wrapper around Reanimated's `measure(ref)`.
+ *
+ * On RN >= 0.81, `measure(ref)` can throw on the UI thread
+ * if the ref isn't attached to a native view yet, causing an
+ * app crash with JSI error: "Value is null, expected an Object".
+ */
+export const safeMeasure = <T extends Component>(ref: AnimatedRef<T>) => {
+  'worklet';
+
+  try {
+    const measurement = measure(ref);
+
+    if (!measurement || (measurement.width === 0 && measurement.height === 1)) {
+      return null;
+    }
+
+    return measurement;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Description

On React Native 0.81 (Fabric; e.g., Expo SDK 54), react-native-reanimated’s measure(ref) can throw on the UI thread if the AnimatedRef isn’t attached to a native node yet. Our hooks (useDraggable, useDroppable) call measure() during/around first layout and gesture begin. Although we checked for null, the exception occurs before a value is returned, causing an app crash (JSI: “Value is null, expected an Object”) as soon as the screen mounts—no user interaction needed.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Testing

- [x] Tested on iOS
- [x] Tested on Android
- [ ] Added/updated tests
- [x] All existing tests pass


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Changes

* Add safeMeasure(ref) (worklet-safe wrapper) that:
* Catches Fabric’s throw and returns null instead.
* Treats 0×0 as “not ready” to avoid registering stale bounds.
* Preserves 'worklet' directive for UI-thread use.
* Introduce nodeReady (useSharedValue(false)) in both hooks and flip it to true on first onLayout.
* Guard all measuring behind nodeReady and replace direct measure(ref) calls with safeMeasure(ref):
* useDraggable: updateDraggablePosition, updateDraggablePositionWorklet, and gesture.onBegin.
* useDroppable: initial/updated registration path.


## References

Fixes #29 
