### PR TITLE
feat(draggable): add press delay to draggable items

### DIFF
--- a/example-app/components/examples/BasicDragDropExample.tsx
+++ b/example-app/components/examples/BasicDragDropExample.tsx
@@ -106,8 +106,34 @@ export function BasicDragDropExample({ onBack }: BasicDragDropExampleProps) {
                     <Text style={styles.cardHint}>Drag me too!</Text>
                   </View>
                 </Draggable>
-              </View>
 
+     
+              </View>
+              <View style={styles.draggableItemsArea}>
+              <Draggable<DraggableItemData>
+                  key="basic-item-3"
+                  preDragDelay={200}
+                  data={{
+                    id: "basic-item-3",
+                    label: "Draggable Item 3",
+                    backgroundColor: "#bde0fe",
+                  }}
+                  style={[
+                    styles.draggable,
+                    {
+                      top: 0,
+                      left: "27%",
+                      backgroundColor: "#bde0fe",
+                      borderRadius: 12,
+                    },
+                  ]}
+                >
+                  <View style={[styles.cardContent, { width: "100%"}]} >
+                    <Text style={styles.cardLabel}>Item 3</Text>
+                    <Text style={styles.cardHint}>With delay of 200ms</Text>
+                  </View>
+                </Draggable>
+              </View>
               <View style={styles.infoContainer}>
                 <View style={styles.infoItem}>
                   <View

--- a/example-app/components/examples/BasicDragDropExample.tsx
+++ b/example-app/components/examples/BasicDragDropExample.tsx
@@ -106,11 +106,9 @@ export function BasicDragDropExample({ onBack }: BasicDragDropExampleProps) {
                     <Text style={styles.cardHint}>Drag me too!</Text>
                   </View>
                 </Draggable>
-
-     
               </View>
               <View style={styles.draggableItemsArea}>
-              <Draggable<DraggableItemData>
+                <Draggable<DraggableItemData>
                   key="basic-item-3"
                   preDragDelay={200}
                   data={{
@@ -128,7 +126,7 @@ export function BasicDragDropExample({ onBack }: BasicDragDropExampleProps) {
                     },
                   ]}
                 >
-                  <View style={[styles.cardContent, { width: "100%"}]} >
+                  <View style={[styles.cardContent, { width: "100%" }]}>
                     <Text style={styles.cardLabel}>Item 3</Text>
                     <Text style={styles.cardHint}>With delay of 200ms</Text>
                   </View>

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -605,7 +605,7 @@ export const useDraggable = <TData = unknown>(
   const gesture = React.useMemo<GestureType>(
     () =>
       Gesture.Pan()
-        .activateAfterLongPress(preDragDelayShared.value)
+        .activateAfterLongPress(preDragDelayShared)
         // We use onStart to detect the initial drag start after the preDragDelay
         .onStart(() => {
           "worklet";

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -145,6 +145,7 @@ export const useDraggable = <TData = unknown>(
     data,
     draggableId,
     dragDisabled = false,
+    preDragDelay = 0,
     onDragStart,
     onDragEnd,
     onDragging,
@@ -204,6 +205,7 @@ export const useDraggable = <TData = unknown>(
   const offsetY = useSharedValue(0);
   const dragDisabledShared = useSharedValue(dragDisabled);
   const dragAxisShared = useSharedValue(dragAxis);
+  const preDragDelayShared = useSharedValue(preDragDelay);
 
   const originX = useSharedValue(0);
   const originY = useSharedValue(0);
@@ -233,6 +235,11 @@ export const useDraggable = <TData = unknown>(
     onDragStart: contextOnDragStart,
     onDragEnd: contextOnDragEnd,
   } = useContext(SlotsContext) as SlotsContextValue<TData>;
+
+
+  useEffect(() => {
+    preDragDelayShared.value = preDragDelay;
+  }, [preDragDelay, preDragDelayShared]);
 
   useEffect(() => {
     dragDisabledShared.value = dragDisabled;
@@ -599,7 +606,9 @@ export const useDraggable = <TData = unknown>(
   const gesture = React.useMemo<GestureType>(
     () =>
       Gesture.Pan()
-        .onBegin(() => {
+        .activateAfterLongPress(preDragDelayShared.value)
+        // We use onStart to detect the initial drag start after the preDragDelay
+        .onStart(() => {
           "worklet";
           //first update the position
           updateDraggablePositionWorklet();

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -236,7 +236,6 @@ export const useDraggable = <TData = unknown>(
     onDragEnd: contextOnDragEnd,
   } = useContext(SlotsContext) as SlotsContextValue<TData>;
 
-
   useEffect(() => {
     preDragDelayShared.value = preDragDelay;
   }, [preDragDelay, preDragDelayShared]);

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -605,7 +605,7 @@ export const useDraggable = <TData = unknown>(
   const gesture = React.useMemo<GestureType>(
     () =>
       Gesture.Pan()
-        .activateAfterLongPress(preDragDelayShared)
+        .activateAfterLongPress(preDragDelay)
         // We use onStart to detect the initial drag start after the preDragDelay
         .onStart(() => {
           "worklet";

--- a/types/draggable.ts
+++ b/types/draggable.ts
@@ -115,6 +115,13 @@ export interface UseDraggableOptions<TData = unknown> {
   dragDisabled?: boolean;
 
   /**
+   * Delay in milliseconds before dragging starts.
+   *
+   * @default 0
+   */
+  preDragDelay?: number;
+
+  /**
    * Callback fired when dragging starts.
    *
    * @param data - The data associated with the draggable item


### PR DESCRIPTION
## Description

Adds an option for a press delay before starting a drag to avoid accidental drags and improve UX when distinguishing between tap vs drag gestures.  
- New support for `pressDelay` in `Draggable` and related hook, allowing configuration (in milliseconds) of when the drag should be activated after a `press`.  
- Default behavior remains unchanged (`pressDelay = 0`), so it is fully backward compatible.  
- Updated the example to demonstrate the behavior with and without delay.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [X] Tested on iOS
- [X] Tested on Android
- [ ] Added/updated tests
- [X] All existing tests pass

## Screenshots/Videos

https://github.com/user-attachments/assets/ba71a799-dfaa-4398-91cc-185cc894cb2b

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

## Reference
Related to #31 

