### PR TITLE
Add optional DragOverlay system for smooth root-level dragging

### DIFF
--- a/components/DragOverlay.tsx
+++ b/components/DragOverlay.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { Modal, StyleSheet, View } from 'react-native';
+import Animated, {
+    SharedValue,
+    useAnimatedStyle,
+    useSharedValue
+} from 'react-native-reanimated';
+
+export interface IDragOverlayProps<TData = any> {
+  /**
+   * The ID of the currently dragging item, provided by the DropProvider context.
+   * When null, the overlay is hidden.
+   */
+  activeDraggableId: string | null;
+  
+  /**
+   * The data of the currently dragging item
+   */
+  activeDraggableData: TData | null;
+  
+  /**
+   * Current position of the dragged item (for initial render)
+   */
+  position: { x: number; y: number };
+  
+  /**
+   * Shared value for X position (updates immediately on UI thread)
+   */
+  positionX?: SharedValue<number>;
+  
+  /**
+   * Shared value for Y position (updates immediately on UI thread)
+   */
+  positionY?: SharedValue<number>;
+  
+  /**
+   * A render prop to allow users to customize the clone's appearance
+   * (e.g., adding shadows or scale effects) without affecting the original item.
+   */
+  children: (data: TData, draggableProps: IInternalDraggableState) => React.ReactNode;
+  
+  /**
+   * Called when the drag gesture ends
+   */
+  onDragEnd: () => void;
+  
+  /**
+   * Optional style for the overlay container
+   */
+  style?: any;
+}
+
+export interface IInternalDraggableState {
+  /**
+   * Whether the item is currently being dragged
+   */
+  isDragging: boolean;
+  
+  /**
+   * Current position offset
+   */
+  position: { x: number; y: number };
+  
+  /**
+   * Scale factor for visual feedback
+   */
+  scale: number;
+  
+  /**
+   * Opacity for visual feedback
+   */
+  opacity: number;
+}
+
+/**
+ * DragOverlay component that renders a dragged item clone at the root level
+ * using React Native's Modal to ensure it appears above all other content.
+ * 
+ * This component automatically handles the high z-index and positioning
+ * to solve Kanban-style overlapping issues.
+ */
+export const DragOverlay = <TData = any>({
+  activeDraggableId,
+  activeDraggableData,
+  position,
+  positionX,
+  positionY,
+  children,
+  onDragEnd,
+  style,
+}: IDragOverlayProps<TData>) => {
+  // Use shared values directly from context if provided (no React state delay)
+  // Otherwise fall back to local shared values synced from position prop
+  const sharedX = positionX || useSharedValue(position.x);
+  const sharedY = positionY || useSharedValue(position.y);
+  const isVisible = useSharedValue(activeDraggableId ? 1 : 0);
+
+  // Only sync from position prop if shared values weren't provided from context
+  React.useLayoutEffect(() => {
+    if (!positionX || !positionY) {
+      sharedX.value = position.x;
+      sharedY.value = position.y;
+    }
+  }, [position.x, position.y, sharedX, sharedY, positionX, positionY]);
+
+  // Update visibility immediately
+  React.useLayoutEffect(() => {
+    isVisible.value = activeDraggableId ? 1 : 0;
+  }, [activeDraggableId, isVisible]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const visible = isVisible.value === 1;
+    
+    return {
+      // Use transform with shared values for better performance and hardware acceleration
+      // These update immediately on UI thread when positionX/positionY change
+      transform: [
+        { translateX: sharedX.value },
+        { translateY: sharedY.value },
+        { scale: 1.15 }, // Larger scale for better visibility
+      ],
+      opacity: visible ? 1.0 : 0, // Control visibility with opacity for instant updates
+      // Hide completely when not visible to avoid touch interference
+      pointerEvents: visible ? 'auto' : 'none',
+    };
+  });
+
+  const draggableState: IInternalDraggableState = {
+    isDragging: !!activeDraggableId,
+    position: position,
+    scale: 1.15,
+    opacity: activeDraggableId ? 1.0 : 0,
+  };
+
+  // Only render Modal when there's an active draggable to avoid blocking the app
+  // The shared values ensure position updates are immediate even with mount/unmount
+  if (!activeDraggableId || !activeDraggableData) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible={true}
+      transparent={true}
+      animationType="none"
+      statusBarTranslucent={true}
+      onRequestClose={() => {}}
+    >
+      <View style={styles.overlayContainer} pointerEvents="box-none">
+        <Animated.View style={[styles.dragItem, animatedStyle, style]}>
+          {children(activeDraggableData, draggableState)}
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlayContainer: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'transparent',
+    pointerEvents: 'box-none',
+    // Ensure it's above everything
+    elevation: 999999,
+    zIndex: 999999,
+  },
+  dragItem: {
+    // Use absolute positioning with fixed layout
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    // NO shadows, NO effects - fully opaque solid card
+    elevation: 999999,
+    zIndex: 999999,
+    backgroundColor: 'transparent',
+  },
+});

--- a/components/Draggable.tsx
+++ b/components/Draggable.tsx
@@ -1,16 +1,15 @@
 // Node Modules
-import React, { useRef, createContext, useContext, useState } from "react";
-import { ViewStyle, StyleProp } from "react-native";
-import Animated from "react-native-reanimated";
+import React, { createContext, useContext } from "react";
 import { GestureDetector } from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
 import { useDraggable } from "../hooks/useDraggable";
 import {
-  UseDraggableOptions,
-  CollisionAlgorithm,
-  DraggableState,
-  DraggableContextValue,
-  DraggableHandleProps,
-  DraggableProps,
+    CollisionAlgorithm,
+    DraggableContextValue,
+    DraggableHandleProps,
+    DraggableProps,
+    DraggableState,
+    UseDraggableOptions,
 } from "../types/draggable";
 
 // Create a context to share gesture and state between Draggable and Handle

--- a/context/DragOverlayContext.tsx
+++ b/context/DragOverlayContext.tsx
@@ -1,0 +1,116 @@
+import React, { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+import { DragOverlay } from '../components/DragOverlay';
+
+export interface IDragOverlayContextType<TData = any> {
+  /**
+   * Show the drag overlay with the specified item
+   */
+  showDragOverlay: (draggableId: string, data: TData, position: { x: number; y: number }) => void;
+  
+  /**
+   * Hide the drag overlay
+   */
+  hideDragOverlay: () => void;
+  
+  /**
+   * Update the position of the drag overlay
+   */
+  updateDragOverlayPosition: (position: { x: number; y: number }) => void;
+  
+  /**
+   * Get the current active draggable ID
+   */
+  getActiveDraggableId: () => string | null;
+}
+
+const DragOverlayContext = createContext<IDragOverlayContextType | undefined>(undefined);
+
+export const useDragOverlay = <TData = any>(): IDragOverlayContextType<TData> => {
+  const context = useContext(DragOverlayContext);
+  if (!context) {
+    throw new Error('useDragOverlay must be used within a DragOverlayProvider');
+  }
+  return context as IDragOverlayContextType<TData>;
+};
+
+export interface IDragOverlayProviderProps<TData = any> {
+  children: ReactNode;
+  
+  /**
+   * Custom render function for the drag overlay
+   * If not provided, uses a default implementation
+   */
+  renderDragOverlay?: (data: TData, draggableState: any) => React.ReactNode;
+}
+
+export const DragOverlayProvider = <TData = any>({
+  children,
+  renderDragOverlay,
+}: IDragOverlayProviderProps<TData>) => {
+  const [activeDraggableId, setActiveDraggableId] = useState<string | null>(null);
+  const [activeDraggableData, setActiveDraggableData] = useState<TData | null>(null);
+  
+  // Use shared values for position to enable smooth Reanimated animations
+  const positionX = useSharedValue(0);
+  const positionY = useSharedValue(0);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const showDragOverlay = useCallback((draggableId: string, data: TData, initialPosition: { x: number; y: number }) => {
+    // Update shared values immediately (runs synchronously, no React state delay)
+    positionX.value = initialPosition.x;
+    positionY.value = initialPosition.y;
+    // Update React state for component rendering
+    setActiveDraggableId(draggableId);
+    setActiveDraggableData(data);
+    setPosition(initialPosition);
+  }, [positionX, positionY]);
+
+  const hideDragOverlay = useCallback(() => {
+    setActiveDraggableId(null);
+    setActiveDraggableData(null);
+  }, []);
+
+  const updateDragOverlayPosition = useCallback((newPosition: { x: number; y: number }) => {
+    // Update shared values immediately (runs on UI thread, no React state delay)
+    positionX.value = newPosition.x;
+    positionY.value = newPosition.y;
+    // Also update React state for initial render, but shared values are the source of truth
+    setPosition(newPosition);
+  }, [positionX, positionY]);
+
+  const getActiveDraggableId = useCallback(() => {
+    return activeDraggableId;
+  }, [activeDraggableId]);
+
+  const contextValue: IDragOverlayContextType<TData> = {
+    showDragOverlay,
+    hideDragOverlay,
+    updateDragOverlayPosition,
+    getActiveDraggableId,
+  };
+
+  // Default render function if none provided
+  const defaultRenderDragOverlay = useCallback((data: TData, draggableState: any) => {
+    // This is a fallback - in practice, the Draggable component should provide its own render function
+    return null;
+  }, []);
+
+  const dragOverlayRenderFunction = renderDragOverlay || defaultRenderDragOverlay;
+
+  return (
+    <DragOverlayContext.Provider value={contextValue}>
+      {children}
+      <DragOverlay
+        activeDraggableId={activeDraggableId}
+        activeDraggableData={activeDraggableData}
+        position={position}
+        positionX={positionX}
+        positionY={positionY}
+        onDragEnd={hideDragOverlay}
+      >
+        {dragOverlayRenderFunction}
+      </DragOverlay>
+    </DragOverlayContext.Provider>
+  );
+};

--- a/example-app/components/ExamplesNavigationPage.tsx
+++ b/example-app/components/ExamplesNavigationPage.tsx
@@ -142,6 +142,13 @@ const examples: Example[] = [
     component: "CustomDraggableExample",
     icon: "⚙️",
   },
+  {
+    id: "dragOverlay",
+    title: "Drag Overlay",
+    description: "Optional overlay system for smooth root-level dragging",
+    component: "DragOverlayExample",
+    icon: "🎭",
+  },
 ];
 
 interface ExamplesNavigationPageProps {

--- a/example-app/components/examples/DragOverlayExample.tsx
+++ b/example-app/components/examples/DragOverlayExample.tsx
@@ -1,0 +1,265 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import {
+  DragOverlayProvider,
+  DropProvider,
+  Draggable,
+  Droppable,
+} from "@/external-lib";
+import { ExampleHeader } from "../ExampleHeader";
+
+interface Card {
+  id: string;
+  title: string;
+  color: string;
+}
+
+const initialCards: Card[] = [
+  { id: "1", title: "Card 1", color: "#FF6B6B" },
+  { id: "2", title: "Card 2", color: "#4ECDC4" },
+  { id: "3", title: "Card 3", color: "#45B7D1" },
+  { id: "4", title: "Card 4", color: "#FFA07A" },
+  { id: "5", title: "Card 5", color: "#98D8C8" },
+];
+
+interface DragOverlayExampleProps {
+  onBack: () => void;
+}
+
+export function DragOverlayExample({ onBack }: DragOverlayExampleProps) {
+  const [cards, setCards] = useState<Card[]>(initialCards);
+  const [droppedCards, setDroppedCards] = useState<Card[]>([]);
+
+  const handleDrop = (data: Card) => {
+    setCards((prev) => prev.filter((card) => card.id !== data.id));
+    setDroppedCards((prev) => [...prev, data]);
+  };
+
+  const handleReset = () => {
+    setCards(initialCards);
+    setDroppedCards([]);
+  };
+
+  return (
+    <GestureHandlerRootView style={styles.container}>
+      <ExampleHeader
+        title="Drag Overlay Example"
+        onBack={onBack}
+        description="Demonstrates the optional DragOverlay system for smooth drag-and-drop with root-level overlay rendering. The overlay appears above all content during drag operations."
+      />
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Drag Cards to Drop Zone</Text>
+          <Text style={styles.sectionDescription}>
+            Cards use the DragOverlay system for smooth dragging. The overlay
+            renders at the root level using Modal, ensuring it appears above all
+            content without z-index issues.
+          </Text>
+        </View>
+
+        <View style={styles.cardsContainer}>
+          {cards.map((card) => (
+            <Draggable key={card.id} data={card}>
+              <View style={[styles.card, { backgroundColor: card.color }]}>
+                <Text style={styles.cardText}>{card.title}</Text>
+              </View>
+            </Draggable>
+          ))}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Drop Zone</Text>
+          <Droppable onDrop={handleDrop}>
+            <View style={styles.dropZone}>
+              {droppedCards.length === 0 ? (
+                <Text style={styles.dropZoneText}>
+                  Drop cards here to move them
+                </Text>
+              ) : (
+                <View style={styles.droppedCardsContainer}>
+                  {droppedCards.map((card) => (
+                    <View
+                      key={card.id}
+                      style={[styles.droppedCard, { backgroundColor: card.color }]}
+                    >
+                      <Text style={styles.cardText}>{card.title}</Text>
+                    </View>
+                  ))}
+                </View>
+              )}
+            </View>
+          </Droppable>
+        </View>
+
+        <TouchableOpacity style={styles.resetButton} onPress={handleReset}>
+          <Text style={styles.resetButtonText}>Reset</Text>
+        </TouchableOpacity>
+
+        <View style={styles.infoSection}>
+          <Text style={styles.infoTitle}>How it works:</Text>
+          <Text style={styles.infoText}>
+            • DragOverlayProvider wraps the app to enable the overlay system
+          </Text>
+          <Text style={styles.infoText}>
+            • Draggable components automatically use the overlay when available
+          </Text>
+          <Text style={styles.infoText}>
+            • The overlay renders using Modal for root-level positioning
+          </Text>
+          <Text style={styles.infoText}>
+            • Position updates happen on the UI thread for smooth performance
+          </Text>
+          <Text style={styles.infoText}>
+            • Falls back to z-index approach if DragOverlayProvider is not used
+          </Text>
+        </View>
+      </ScrollView>
+    </GestureHandlerRootView>
+  );
+}
+
+// Wrap the example with DragOverlayProvider
+export function DragOverlayExampleWithProvider({
+  onBack,
+}: DragOverlayExampleProps) {
+  return (
+    <DragOverlayProvider
+      renderDragOverlay={(data: Card) => {
+        return (
+          <View style={[styles.card, { backgroundColor: data.color }]}>
+            <Text style={styles.cardText}>{data.title}</Text>
+          </View>
+        );
+      }}
+    >
+      <DropProvider>
+        <DragOverlayExample onBack={onBack} />
+      </DropProvider>
+    </DragOverlayProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#f5f5f5",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "#333",
+    marginBottom: 8,
+  },
+  sectionDescription: {
+    fontSize: 14,
+    color: "#666",
+    marginBottom: 16,
+    lineHeight: 20,
+  },
+  cardsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+    marginBottom: 24,
+  },
+  card: {
+    width: 100,
+    height: 120,
+    borderRadius: 12,
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  cardText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  dropZone: {
+    minHeight: 200,
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: "#ddd",
+    borderStyle: "dashed",
+    padding: 16,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  dropZoneText: {
+    fontSize: 16,
+    color: "#999",
+    textAlign: "center",
+  },
+  droppedCardsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+    width: "100%",
+  },
+  droppedCard: {
+    width: 80,
+    height: 100,
+    borderRadius: 8,
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.22,
+    shadowRadius: 2.22,
+    elevation: 3,
+  },
+  resetButton: {
+    backgroundColor: "#4ECDC4",
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    alignSelf: "center",
+    marginTop: 16,
+    marginBottom: 24,
+  },
+  resetButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  infoSection: {
+    backgroundColor: "#fff",
+    padding: 16,
+    borderRadius: 8,
+    marginTop: 8,
+  },
+  infoTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+    marginBottom: 12,
+  },
+  infoText: {
+    fontSize: 14,
+    color: "#666",
+    marginBottom: 8,
+    lineHeight: 20,
+  },
+});
+

--- a/example-app/components/examples/index.ts
+++ b/example-app/components/examples/index.ts
@@ -12,3 +12,4 @@ export { YAxisConstrainedExample } from "./YAxisConstrainedExample";
 export { BoundedYAxisExample } from "./BoundedYAxisExample";
 export { CapacityExample } from "./CapacityExample";
 export { CustomDraggableExample } from "./CustomDraggableExample";
+export { DragOverlayExampleWithProvider as DragOverlayExample } from "./DragOverlayExample";

--- a/example-app/navigation/AppNavigator.tsx
+++ b/example-app/navigation/AppNavigator.tsx
@@ -21,6 +21,7 @@ import {
   BoundedYAxisExample,
   CapacityExample,
   CustomDraggableExample,
+  DragOverlayExample,
 } from "@/components/examples";
 import { HorizontalSortableExample } from "@/components/HorizontalSortableExample";
 
@@ -42,6 +43,7 @@ export type RootStackParamList = {
   CapacityExample: undefined;
   CustomDraggableExample: undefined;
   HorizontalSortableExample: undefined;
+  DragOverlayExample: undefined;
 };
 
 const Stack = createStackNavigator<RootStackParamList>();
@@ -155,6 +157,12 @@ function HorizontalSortableExampleScreen({
   return <HorizontalSortableExample onBack={() => navigation.goBack()} />;
 }
 
+function DragOverlayExampleScreen({
+  navigation,
+}: StackScreenProps<RootStackParamList, "DragOverlayExample">) {
+  return <DragOverlayExample onBack={() => navigation.goBack()} />;
+}
+
 export function AppNavigator() {
   return (
     <NavigationContainer>
@@ -231,6 +239,10 @@ export function AppNavigator() {
         <Stack.Screen
           name="HorizontalSortableExample"
           component={HorizontalSortableExampleScreen}
+        />
+        <Stack.Screen
+          name="DragOverlayExample"
+          component={DragOverlayExampleScreen}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/hooks/useDraggable.ts
+++ b/hooks/useDraggable.ts
@@ -1,41 +1,41 @@
 // hooks/useDraggable.ts
 import React, {
-  useRef,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
 } from "react";
 import { LayoutChangeEvent } from "react-native";
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withSpring,
-  runOnJS,
-  runOnUI,
-  AnimatedStyle,
-  useAnimatedReaction,
-  useAnimatedRef,
-  measure,
-} from "react-native-reanimated";
 import {
-  Gesture,
-  PanGestureHandlerEventPayload,
-  GestureType,
+    Gesture,
+    GestureType,
+    PanGestureHandlerEventPayload,
 } from "react-native-gesture-handler";
+import Animated, {
+    measure,
+    runOnJS,
+    runOnUI,
+    useAnimatedReaction,
+    useAnimatedRef,
+    useAnimatedStyle,
+    useSharedValue,
+    withSpring
+} from "react-native-reanimated";
+import { useDragOverlay } from "../context/DragOverlayContext";
 import {
-  SlotsContext,
-  SlotsContextValue,
-  DropAlignment,
-  DropOffset,
-  DropSlot,
+    DropAlignment,
+    DropOffset,
+    DropSlot,
+    SlotsContext,
+    SlotsContextValue,
 } from "../types/context";
 import {
-  DraggableState,
-  AnimationFunction,
-  CollisionAlgorithm,
-  UseDraggableOptions,
-  UseDraggableReturn,
+    AnimationFunction,
+    CollisionAlgorithm,
+    DraggableState,
+    UseDraggableOptions,
+    UseDraggableReturn,
 } from "../types/draggable";
 
 /**
@@ -165,6 +165,24 @@ export const useDraggable = <TData = unknown>(
   const [state, setState] = useState<DraggableState>(DraggableState.IDLE);
   const [hasHandle, setHasHandle] = useState(false);
 
+    // HYBRID APPROACH: Use DragOverlay only when available, fallback to z-index
+    let showDragOverlay, hideDragOverlay, updateDragOverlayPosition;
+    let useDragOverlaySystem = false;
+    
+    try {
+      const overlayContext = useDragOverlay();
+      showDragOverlay = overlayContext.showDragOverlay;
+      hideDragOverlay = overlayContext.hideDragOverlay;
+      updateDragOverlayPosition = overlayContext.updateDragOverlayPosition;
+      useDragOverlaySystem = true;
+    } catch (error: any) {
+      // DragOverlay system not available, fallback to z-index approach
+      showDragOverlay = () => {};
+      hideDragOverlay = () => {};
+      updateDragOverlayPosition = () => {};
+      useDragOverlaySystem = false;
+    }
+
   // Check if any child is a Handle component
   useEffect(() => {
     if (!children || !handleComponent) {
@@ -195,10 +213,7 @@ export const useDraggable = <TData = unknown>(
     setHasHandle(React.Children.toArray(children).some(checkForHandle));
   }, [children, handleComponent]);
 
-  useEffect(() => {
-    onStateChange?.(state);
-  }, [state, onStateChange]);
-
+  // Shared values MUST be declared before any useEffect that uses them
   const tx = useSharedValue(0);
   const ty = useSharedValue(0);
   const offsetX = useSharedValue(0);
@@ -206,6 +221,13 @@ export const useDraggable = <TData = unknown>(
   const dragDisabledShared = useSharedValue(dragDisabled);
   const dragAxisShared = useSharedValue(dragAxis);
   const preDragDelayShared = useSharedValue(preDragDelay);
+  const isDraggingShared = useSharedValue(0); // Track dragging state for worklets (0 = not dragging, 1 = dragging)
+  
+  useEffect(() => {
+    onStateChange?.(state);
+    // Keep shared value in sync with React state for worklets
+    isDraggingShared.value = state === DraggableState.DRAGGING ? 1 : 0;
+  }, [state, onStateChange, isDraggingShared]);
 
   const originX = useSharedValue(0);
   const originY = useSharedValue(0);
@@ -605,7 +627,7 @@ export const useDraggable = <TData = unknown>(
   const gesture = React.useMemo<GestureType>(
     () =>
       Gesture.Pan()
-        .activateAfterLongPress(preDragDelay)
+        .activateAfterLongPress(preDragDelay > 0 ? preDragDelay : undefined)
         // We use onStart to detect the initial drag start after the preDragDelay
         .onStart(() => {
           "worklet";
@@ -614,8 +636,28 @@ export const useDraggable = <TData = unknown>(
           if (dragDisabledShared.value) return;
           offsetX.value = tx.value;
           offsetY.value = ty.value;
-          // Update state to DRAGGING when drag begins
+          
+          // CRITICAL: Set dragging state immediately on UI thread to hide original item instantly
+          // This prevents the brief flash on Android where the original item might show
+          // before the Modal overlay appears
+          isDraggingShared.value = 1;
+          
+          // Update state to DRAGGING when drag begins (for JS thread callbacks)
           runOnJS(setState)(DraggableState.DRAGGING);
+          
+          // HYBRID: Use DragOverlay if available, otherwise rely on z-index
+          if (useDragOverlaySystem) {
+            // Use the actual screen position (origin) as initial position
+            // This ensures the overlay appears exactly where the item is
+            const initialX = originX.value;
+            const initialY = originY.value;
+            runOnJS(showDragOverlay)(
+              draggableId || `draggable-${Date.now()}`,
+              data,
+              { x: initialX, y: initialY } // Use actual screen position
+            );
+          }
+          
           if (onDragStart) runOnJS(onDragStart)(data);
           if (contextOnDragStart) runOnJS(contextOnDragStart)(data);
         })
@@ -662,6 +704,18 @@ export const useDraggable = <TData = unknown>(
               itemData: data,
             });
           }
+          // Update drag overlay position using origin + translation
+          if (useDragOverlaySystem) {
+            // Use absolute position: where the card started + how much it moved
+            const currentPageX = originX.value + tx.value;
+            const currentPageY = originY.value + ty.value;
+            
+            runOnJS(updateDragOverlayPosition)({
+              x: currentPageX,
+              y: currentPageY,
+            });
+          }
+          
           runOnJS(updateHoverState)(
             tx.value,
             ty.value,
@@ -674,6 +728,16 @@ export const useDraggable = <TData = unknown>(
         .onEnd(() => {
           "worklet";
           if (dragDisabledShared.value) return;
+          
+          // CRITICAL: Reset dragging state immediately on UI thread
+          // This ensures the original item becomes visible again instantly
+          isDraggingShared.value = 0;
+          
+          // Hide the drag overlay when drag ends
+          if (useDragOverlaySystem) {
+            runOnJS(hideDragOverlay)();
+          }
+          
           if (onDragEnd) runOnJS(onDragEnd)(data);
           if (contextOnDragEnd) runOnJS(contextOnDragEnd)(data);
           runOnJS(processDropAndAnimate)(
@@ -716,15 +780,24 @@ export const useDraggable = <TData = unknown>(
       contextOnDragging,
       contextOnDragStart,
       contextOnDragEnd,
+      isDraggingShared,
     ]
   );
 
   const animatedStyleProp = useAnimatedStyle(() => {
     "worklet";
+    const isDragging = isDraggingShared.value === 1;
+    const shouldHide = useDragOverlaySystem && isDragging;
+    
+    // When using DragOverlay system, hide the original card completely
+    // When NOT using DragOverlay, raise z-index for stacking
     return {
       transform: [{ translateX: tx.value }, { translateY: ty.value }] as const,
+      opacity: shouldHide ? 0 : 1,  // Hide original when dragging with overlay
+      zIndex: !useDragOverlaySystem && isDragging ? 9999 : 1,
+      elevation: !useDragOverlaySystem && isDragging ? 9999 : 1,
     };
-  }, [tx, ty]);
+  }, [tx, ty, isDraggingShared, useDragOverlaySystem]);
 
   // Replace the React useEffect with useAnimatedReaction to properly handle shared values
   useAnimatedReaction(
@@ -740,13 +813,17 @@ export const useDraggable = <TData = unknown>(
     (result, previous) => {
       // Only trigger when values change to zero (returned to original position)
       if (result.isZero && previous && !previous.isZero) {
+        // Reset dragging state immediately on UI thread
+        isDraggingShared.value = 0;
         // Use runOnJS to call setState from the UI thread
         runOnJS(setState)(DraggableState.IDLE);
         // When returning to origin position, we know we're no longer dropped
         runOnJS(unregisterDroppedItem)(internalDraggableId);
+        // Hide the drag overlay when drag is complete
+        runOnJS(hideDragOverlay)();
       }
     },
-    [setState, unregisterDroppedItem, internalDraggableId]
+    [setState, unregisterDroppedItem, internalDraggableId, hideDragOverlay]
   );
 
   // Clean up on unmount

--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,12 @@
 // Components
 export { Draggable } from "./components/Draggable";
+export { DragOverlay } from "./components/DragOverlay";
 export { Droppable } from "./components/Droppable";
 export { Sortable } from "./components/Sortable";
 export { SortableItem } from "./components/SortableItem";
 
 // Context
+export { DragOverlayProvider, useDragOverlay } from "./context/DragOverlayContext";
 export { DropProvider } from "./context/DropContext";
 
 // Types


### PR DESCRIPTION

This PR fixes issue where the Droppable component or parent overlaps the Draggable  component.

https://github.com/entropyconquers/react-native-reanimated-dnd/issues/17

- Add DragOverlay component using Modal for root-level rendering
- Add DragOverlayProvider context for optional drag overlay system
- Pass shared values directly from context to avoid React state delays
- Hide original item immediately on UI thread for smooth dragging on Android
- Remove console.log statements from production code
- Ensure backward compatibility - DragOverlay system is optional and gracefully falls back to z-index approach
- Add DragOverlayExample to example app demonstrating usage