### PR TITLE
fix: separate gesture instances for item and handle pan interactions

### DIFF
--- a/components/SortableItem.tsx
+++ b/components/SortableItem.tsx
@@ -84,21 +84,20 @@ function renderSortableContent(
   style: StyleProp<ViewStyle> | undefined,
   children: React.ReactNode,
   panGestureHandler: SortableContextValue["panGestureHandler"],
+  handlePanGestureHandler: SortableContextValue["panGestureHandler"],
   registerHandle: SortableContextValue["registerHandle"],
-  hasHandle: boolean
 ) {
   const content = (
     <Animated.View style={[animatedStyle, customAnimatedStyle]}>
-      <SortableContext.Provider value={{ panGestureHandler, registerHandle }}>
+      <SortableContext.Provider value={{ panGestureHandler: handlePanGestureHandler, registerHandle }}>
         <Animated.View style={style}>{children}</Animated.View>
       </SortableContext.Provider>
     </Animated.View>
   );
 
-  if (hasHandle) {
-    return content;
-  }
-
+  // Always render the outer GestureDetector to avoid mount/unmount cycles
+  // that trigger Reanimated 4's "Tried to modify key handlerTag" warning.
+  // The panGestureHandler is automatically disabled when a handle is registered.
   return (
     <GestureDetector gesture={panGestureHandler}>{content}</GestureDetector>
   );
@@ -126,7 +125,7 @@ function VerticalSortableItemInner<T>({
   onDrop,
   onDragging,
 }: VerticalSortableItemInnerProps<T>) {
-  const { animatedStyle, panGestureHandler, hasHandle, registerHandle } = useSortable<T>({
+  const { animatedStyle, panGestureHandler, handlePanGestureHandler, registerHandle } = useSortable<T>({
     id,
     positions,
     lowerBound,
@@ -146,8 +145,8 @@ function VerticalSortableItemInner<T>({
     style,
     children,
     panGestureHandler,
+    handlePanGestureHandler,
     registerHandle,
-    hasHandle
   );
 }
 
@@ -177,7 +176,7 @@ function HorizontalSortableItemInner<T>({
   onDrop,
   onDraggingHorizontal,
 }: HorizontalSortableItemInnerProps<T>) {
-  const { animatedStyle, panGestureHandler, hasHandle, registerHandle } =
+  const { animatedStyle, panGestureHandler, handlePanGestureHandler, registerHandle } =
     useHorizontalSortable<T>({
       id,
       positions,
@@ -200,8 +199,8 @@ function HorizontalSortableItemInner<T>({
     style,
     children,
     panGestureHandler,
+    handlePanGestureHandler,
     registerHandle,
-    hasHandle
   );
 }
 

--- a/hooks/useHorizontalSortable.ts
+++ b/hooks/useHorizontalSortable.ts
@@ -345,54 +345,61 @@ export function useHorizontalSortable<T>(
     [movingSV]
   );
 
-  const panGestureHandler: GestureType = Gesture.Pan()
-    .activateAfterLongPress(200)
-    .shouldCancelWhenOutside(false)
-    .onStart((event) => {
-      "worklet";
-      initialItemContentX.value = getItemXPosition(
-        positions.value[id],
-        itemWidth,
-        gap,
-        paddingHorizontal
-      );
-      initialFingerAbsoluteX.value = event.absoluteX;
-      initialLeftBound.value = leftBound.value;
+  const createPanGesture = () =>
+    Gesture.Pan()
+      .activateAfterLongPress(200)
+      .shouldCancelWhenOutside(false)
+      .onStart((event) => {
+        "worklet";
+        initialItemContentX.value = getItemXPosition(
+          positions.value[id],
+          itemWidth,
+          gap,
+          paddingHorizontal
+        );
+        initialFingerAbsoluteX.value = event.absoluteX;
+        initialLeftBound.value = leftBound.value;
 
-      positionX.value = initialItemContentX.value;
-      movingSV.value = true;
-      scheduleOnRN(setIsMoving, true);
+        positionX.value = initialItemContentX.value;
+        movingSV.value = true;
+        scheduleOnRN(setIsMoving, true);
 
-      if (onDragStart) {
-        scheduleOnRN(onDragStart, id, positions.value[id]);
-      }
-    })
-    .onUpdate((event) => {
-      "worklet";
-      const fingerDxScreen = event.absoluteX - initialFingerAbsoluteX.value;
-      const scrollDeltaSinceStart = leftBound.value - initialLeftBound.value;
-      positionX.value =
-        initialItemContentX.value + fingerDxScreen + scrollDeltaSinceStart;
-    })
-    .onFinalize(() => {
-      "worklet";
-      const finishPosition = getItemXPosition(
-        positions.value[id],
-        itemWidth,
-        gap,
-        paddingHorizontal
-      );
-      left.value = withTiming(finishPosition);
-      movingSV.value = false;
-      scheduleOnRN(setIsMoving, false);
+        if (onDragStart) {
+          scheduleOnRN(onDragStart, id, positions.value[id]);
+        }
+      })
+      .onUpdate((event) => {
+        "worklet";
+        const fingerDxScreen = event.absoluteX - initialFingerAbsoluteX.value;
+        const scrollDeltaSinceStart = leftBound.value - initialLeftBound.value;
+        positionX.value =
+          initialItemContentX.value + fingerDxScreen + scrollDeltaSinceStart;
+      })
+      .onFinalize(() => {
+        "worklet";
+        const finishPosition = getItemXPosition(
+          positions.value[id],
+          itemWidth,
+          gap,
+          paddingHorizontal
+        );
+        left.value = withTiming(finishPosition);
+        movingSV.value = false;
+        scheduleOnRN(setIsMoving, false);
 
-      if (onDrop) {
-        const positionsCopy = { ...positions.value };
-        scheduleOnRN(onDrop, id, positions.value[id], positionsCopy);
-      }
+        if (onDrop) {
+          const positionsCopy = { ...positions.value };
+          scheduleOnRN(onDrop, id, positions.value[id], positionsCopy);
+        }
 
-      currentOverItemId.value = null;
-    });
+        currentOverItemId.value = null;
+      });
+
+  // Main gesture for full-item dragging — disabled when a handle is registered
+  const panGestureHandler: GestureType = createPanGesture().enabled(!hasHandle);
+
+  // Separate gesture for handle-only dragging
+  const handlePanGestureHandler: GestureType = createPanGesture();
 
   const animatedStyle = useAnimatedStyle(() => {
     "worklet";
@@ -413,6 +420,7 @@ export function useHorizontalSortable<T>(
   return {
     animatedStyle,
     panGestureHandler,
+    handlePanGestureHandler,
     isMoving,
     hasHandle,
     registerHandle,

--- a/hooks/useSortable.ts
+++ b/hooks/useSortable.ts
@@ -135,6 +135,7 @@ export interface UseSortableOptions<T> {
 export interface UseSortableReturn {
   animatedStyle: StyleProp<ViewStyle>;
   panGestureHandler: GestureType;
+  handlePanGestureHandler: GestureType;
   isMoving: boolean;
   hasHandle: boolean;
   registerHandle: (registered: boolean) => void;
@@ -441,44 +442,52 @@ export function useSortable<T>(
     [movingSV]
   );
 
-  const panGestureHandler: GestureType = Gesture.Pan()
-    .activateAfterLongPress(200)
-    .shouldCancelWhenOutside(false)
-    .onStart((event) => {
-      "worklet";
-      initialItemContentY.value = positions.value[id] * itemHeight;
-      initialFingerAbsoluteY.value = event.absoluteY;
-      initialLowerBound.value = lowerBound.value;
+  const createPanGesture = () =>
+    Gesture.Pan()
+      .activateAfterLongPress(200)
+      .shouldCancelWhenOutside(false)
+      .onStart((event) => {
+        "worklet";
+        initialItemContentY.value = positions.value[id] * itemHeight;
+        initialFingerAbsoluteY.value = event.absoluteY;
+        initialLowerBound.value = lowerBound.value;
 
-      positionY.value = initialItemContentY.value;
-      movingSV.value = true;
-      scheduleOnRN(setIsMoving, true);
+        positionY.value = initialItemContentY.value;
+        movingSV.value = true;
+        scheduleOnRN(setIsMoving, true);
 
-      if (onDragStart) {
-        scheduleOnRN(onDragStart, id, positions.value[id]);
-      }
-    })
-    .onUpdate((event) => {
-      "worklet";
-      const fingerDyScreen = event.absoluteY - initialFingerAbsoluteY.value;
-      const scrollDeltaSinceStart = lowerBound.value - initialLowerBound.value;
-      positionY.value =
-        initialItemContentY.value + fingerDyScreen + scrollDeltaSinceStart;
-    })
-    .onFinalize(() => {
-      "worklet";
-      const finishPosition = positions.value[id] * itemHeight;
-      top.value = withTiming(finishPosition);
-      movingSV.value = false;
-      scheduleOnRN(setIsMoving, false);
+        if (onDragStart) {
+          scheduleOnRN(onDragStart, id, positions.value[id]);
+        }
+      })
+      .onUpdate((event) => {
+        "worklet";
+        const fingerDyScreen = event.absoluteY - initialFingerAbsoluteY.value;
+        const scrollDeltaSinceStart = lowerBound.value - initialLowerBound.value;
+        positionY.value =
+          initialItemContentY.value + fingerDyScreen + scrollDeltaSinceStart;
+      })
+      .onFinalize(() => {
+        "worklet";
+        const finishPosition = positions.value[id] * itemHeight;
+        top.value = withTiming(finishPosition);
+        movingSV.value = false;
+        scheduleOnRN(setIsMoving, false);
 
-      if (onDrop) {
-        const positionsCopy = { ...positions.value };
-        scheduleOnRN(onDrop, id, positions.value[id], positionsCopy);
-      }
+        if (onDrop) {
+          const positionsCopy = { ...positions.value };
+          scheduleOnRN(onDrop, id, positions.value[id], positionsCopy);
+        }
 
-      currentOverItemId.value = null;
-    });
+        currentOverItemId.value = null;
+      });
+
+  // Main gesture for full-item dragging — disabled when a handle is registered
+  const panGestureHandler: GestureType = createPanGesture().enabled(!hasHandle);
+
+  // Separate gesture for handle-only dragging (avoids sharing a gesture
+  // object between two GestureDetectors and the handlerTag mutation warning)
+  const handlePanGestureHandler: GestureType = createPanGesture();
 
   const animatedStyle = useAnimatedStyle(() => {
     "worklet";
@@ -498,6 +507,7 @@ export function useSortable<T>(
   return {
     animatedStyle,
     panGestureHandler,
+    handlePanGestureHandler,
     isMoving,
     hasHandle,
     registerHandle,

--- a/types/sortable.ts
+++ b/types/sortable.ts
@@ -213,10 +213,17 @@ export interface UseSortableReturn {
   animatedStyle: StyleProp<ViewStyle>;
 
   /**
-   * Pan gesture definition for drag interactions.
-   * Attach this to a GestureDetector to enable dragging.
+   * Pan gesture for full-item drag interactions.
+   * Automatically disabled when a handle is registered.
    */
   panGestureHandler: GestureType;
+
+  /**
+   * Pan gesture for handle-only drag interactions.
+   * A separate gesture instance to avoid sharing a gesture object
+   * between multiple GestureDetectors.
+   */
+  handlePanGestureHandler: GestureType;
 
   /**
    * Whether this item is currently being moved/dragged.
@@ -710,10 +717,17 @@ export interface UseHorizontalSortableReturn {
   animatedStyle: StyleProp<ViewStyle>;
 
   /**
-   * Pan gesture definition for drag interactions.
-   * Attach this to a GestureDetector to enable dragging.
+   * Pan gesture for full-item drag interactions.
+   * Automatically disabled when a handle is registered.
    */
   panGestureHandler: GestureType;
+
+  /**
+   * Pan gesture for handle-only drag interactions.
+   * A separate gesture instance to avoid sharing a gesture object
+   * between multiple GestureDetectors.
+   */
+  handlePanGestureHandler: GestureType;
 
   /**
    * Whether this item is currently being moved/dragged.


### PR DESCRIPTION
## Summary
- Fixes Reanimated 4's "Tried to modify key handlerTag" warning by creating separate gesture instances for item-level and handle-level pan interactions
- Adds `handlePanGestureHandler` to `useSortable` and `useHorizontalSortable` return values
- Always renders the outer `GestureDetector` (with the main gesture disabled when a handle is registered) to avoid mount/unmount cycles that trigger Reanimated 4 warnings

## Changes
- `hooks/useSortable.ts` — Extract `createPanGesture()` factory, create `panGestureHandler` (disabled when handle registered) and `handlePanGestureHandler` (always active)
- `hooks/useHorizontalSortable.ts` — Same pattern for horizontal sortable
- `components/SortableItem.tsx` — Pass `handlePanGestureHandler` to `SortableContext.Provider` instead of sharing the same gesture
- `types/sortable.ts` — Add `handlePanGestureHandler` to return type interfaces

## Test plan
- [ ] Verify drag-and-drop works without handles (full-item drag)
- [ ] Verify drag handles work without "handlerTag" warnings
- [ ] Verify horizontal sortable handle interactions
- [ ] Confirm no regressions in sorting behavior