### PR TITLE
fix: use cumulative heights for initialTopVal in dynamic height mode

### DIFF
--- a/hooks/useSortable.ts
+++ b/hooks/useSortable.ts
@@ -201,8 +201,13 @@ export function useSortable<T>(
   const initialTopVal = useMemo(() => {
     const posArr = positions.get();
     const pos = posArr?.[id] ?? 0;
-    // For dynamic heights, use estimated height for initial position.
-    // The animated reaction will correct it once cumulative heights are available.
+    // Use cumulative heights for correct initial positioning in dynamic height mode
+    if (isDynamicHeight && itemHeights) {
+      const hv = itemHeights.get();
+      if (hv && Object.keys(hv).length > 0) {
+        return getItemCumulativeY(id, posArr, hv, estimatedItemHeight);
+      }
+    }
     return pos * effectiveItemHeight;
   }, []);
 


### PR DESCRIPTION
## Description

Fixes incorrect initial positioning of `SortableItem` components when using `enableDynamicHeights` with items of varying heights.

**Problem:** `initialTopVal` in `useSortable` uses `pos * effectiveItemHeight`, which assumes all items share the same estimated height. When items have different heights (e.g., a 128px item followed by a 64px item), subsequent items overlap the taller item on the first render frame.

The `useAnimatedReaction` that should correct positions via `getItemCumulativeY` doesn't fire on mount because Reanimated provides `oldTop = null` on the first call, and the condition `oldTop !== null` prevents correction.

**Fix:** Use `getItemCumulativeY` (already imported and used elsewhere in the hook) to calculate the correct initial Y position by summing cumulative heights of preceding items. Includes a guard (`Object.keys(hv).length > 0`) for edge cases where `itemHeights` is empty.

Fixes #61

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Tested with a sortable list containing blocks of varying heights (64px single items and 128px grouped items)
- Verified items position correctly from frame 1 without overlap
- Verified no regression for fixed-height lists (`isDynamicHeight = false`)
- Verified fallback works when `itemHeights` is empty

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have tested on iOS