### PR TITLE
feat: add support for variable item heights in sortable grids

### DIFF
--- a/components/SortableGridItem.tsx
+++ b/components/SortableGridItem.tsx
@@ -114,6 +114,7 @@ export function SortableGridItem<T>({
   onDrop,
   onDragging,
   isBeingRemoved,
+  itemIds,
 }: SortableGridItemProps<T>) {
   const gridSortableOptions: UseGridSortableOptions<T> = {
     id,
@@ -133,6 +134,7 @@ export function SortableGridItem<T>({
     onDrop,
     onDragging,
     isBeingRemoved,
+    itemIds,
   };
 
   const { animatedStyle, panGestureHandler, handlePanGestureHandler, registerHandle } =

--- a/example-app/components/ExamplesNavigationPage.tsx
+++ b/example-app/components/ExamplesNavigationPage.tsx
@@ -56,6 +56,13 @@ const categories: Category[] = [
         icon: `⊞${TEXT}`,
       },
       {
+        id: "dynamicGrid",
+        title: "Dynamic Grid",
+        description: "Grid with variable item heights (masonry)",
+        component: "DynamicGridExample",
+        icon: `⚏${TEXT}`,
+      },
+      {
         id: "dynamicHeight",
         title: "Dynamic Heights",
         description: "Sortable list with variable item heights",

--- a/example-app/components/examples/DynamicGridExample.tsx
+++ b/example-app/components/examples/DynamicGridExample.tsx
@@ -1,0 +1,430 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Dimensions,
+  TouchableOpacity,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  SortableGrid,
+  SortableGridItem,
+  SortableGridRenderItemProps,
+  GridOrientation,
+  GridStrategy,
+} from "react-native-reanimated-dnd";
+import { colors, fonts } from "../../theme";
+
+interface GridItem {
+  id: string;
+  title: string;
+  color: string;
+  isTall: boolean;
+}
+
+interface DynamicGridExampleProps {
+  onBack: () => void;
+}
+
+const ITEM_COLORS = [
+  "#FF6B6B",
+  "#4ECDC4",
+  "#45B7D1",
+  "#96CEB4",
+  "#FFEAA7",
+  "#DDA0DD",
+  "#98D8C8",
+  "#F7DC6F",
+  "#BB8FCE",
+  "#85C1E9",
+];
+
+const INITIAL_ITEMS: GridItem[] = [
+  { id: "item-1", title: "Item 1", color: ITEM_COLORS[0], isTall: false },
+  { id: "item-2", title: "Item 2", color: ITEM_COLORS[1], isTall: false },
+  { id: "item-3", title: "Item 3", color: ITEM_COLORS[2], isTall: true },
+  { id: "item-4", title: "Item 4", color: ITEM_COLORS[3], isTall: false },
+  { id: "item-5", title: "Item 5", color: ITEM_COLORS[4], isTall: false },
+];
+
+const TALL_ID = "item-3";
+const RESERVED_ID = "reserved";
+const TOTAL_SLOTS = 6;
+
+let nextId = 6;
+
+function generateRandomItem(): GridItem {
+  const id = `item-${nextId++}`;
+  const randomColor =
+    ITEM_COLORS[Math.floor(Math.random() * ITEM_COLORS.length)];
+  return {
+    id,
+    title: `Item ${nextId - 1}`,
+    color: randomColor,
+    isTall: false,
+  };
+}
+
+const COLUMN_OPTIONS = [2, 3, 4];
+
+export function DynamicGridExample({ onBack }: DynamicGridExampleProps) {
+  const [items, setItems] = useState<GridItem[]>(INITIAL_ITEMS);
+  const [columns, setColumns] = useState(3);
+  const [showControls, setShowControls] = useState(false);
+
+  const { width } = Dimensions.get("window");
+  const gap = 16;
+  const padding = 24;
+  const totalGapWidth = gap * (columns - 1);
+  const totalPaddingWidth = padding * 2;
+  const itemWidth = Math.floor(
+    (width - totalPaddingWidth - totalGapWidth) / columns
+  );
+  const itemHeight = itemWidth * 1.2;
+  const tallHeight = itemHeight * 2 + gap;
+
+  // Normalize slots to include reserved placeholder below tall item
+  const normalizedSlots = useMemo(() => {
+    let updated: (GridItem | { id: string; reserved: true })[] = [...items];
+
+    const tallIndex = updated.findIndex((i) => i.id === TALL_ID);
+    if (tallIndex === -1) return updated;
+
+    const belowIndex = tallIndex + columns;
+
+    if (belowIndex < TOTAL_SLOTS) {
+      updated.splice(belowIndex, 0, { id: RESERVED_ID, reserved: true });
+    }
+
+    return updated;
+  }, [items, columns]);
+
+  // Calculate itemHeights mapping
+  const itemHeights = useMemo(() => {
+    const heights: { [id: string]: number } = {};
+    items.forEach((item) => {
+      heights[item.id] = item.isTall ? tallHeight : itemHeight;
+    });
+    heights[RESERVED_ID] = itemHeight;
+    return heights;
+  }, [items, tallHeight, itemHeight]);
+
+  const handleAddItem = useCallback(() => {
+    setItems((prev) => {
+      if (prev.length >= 5) return prev;
+      const newItem = generateRandomItem();
+      return [newItem, ...prev];
+    });
+  }, []);
+
+  const handleResetItems = useCallback(() => {
+    setItems(INITIAL_ITEMS);
+  }, []);
+
+  const handleDrop = useCallback(
+    (id: string, newPosition: number, allPositions: any) => {
+      const sortedEntries = Object.entries(allPositions).sort(
+        ([, a]: any, [, b]: any) => a.index - b.index
+      );
+      setItems((prevItems) => {
+        const reorderedItems = sortedEntries
+          .map(([itemId]) => prevItems.find((item) => item.id === itemId))
+          .filter((item): item is GridItem => item !== undefined);
+        return reorderedItems;
+      });
+    },
+    []
+  );
+
+  const renderItem = useCallback(
+    (props: SortableGridRenderItemProps<GridItem>) => {
+      const {
+        item,
+        id,
+        positions,
+        scrollY,
+        scrollX,
+        autoScrollDirection,
+        itemsCount,
+        dimensions,
+        orientation,
+        strategy,
+      } = props;
+
+      const slot = item as any;
+
+      if (slot.id === RESERVED_ID) {
+        return (
+          <View
+            key={id}
+            style={{
+              width: itemWidth,
+              height: itemHeight,
+            }}
+          />
+        );
+      }
+
+      const isTall = slot.id === TALL_ID;
+
+      return (
+        <SortableGridItem
+          key={id}
+          id={id}
+          data={item}
+          positions={positions}
+          scrollY={scrollY}
+          scrollX={scrollX}
+          autoScrollDirection={autoScrollDirection}
+          itemsCount={itemsCount}
+          dimensions={dimensions}
+          orientation={orientation}
+          strategy={strategy}
+          onDrop={handleDrop}
+        >
+          <View
+            style={[
+              styles.gridItem,
+              {
+                width: itemWidth,
+                height: isTall ? tallHeight : itemHeight,
+                backgroundColor: item.color,
+              },
+            ]}
+          >
+            <View style={styles.itemHeader}>
+              <Text style={styles.itemTitle}>{item.title}</Text>
+            </View>
+            <Text style={styles.itemSubtitle}>{item.id}</Text>
+          </View>
+        </SortableGridItem>
+      );
+    },
+    [itemWidth, itemHeight, tallHeight, handleDrop]
+  );
+
+  const gridDimensions = useMemo(
+    () => ({
+      columns,
+      itemWidth,
+      itemHeight,
+      rowGap: gap,
+      columnGap: gap,
+      itemHeights,
+    }),
+    [columns, itemWidth, itemHeight, gap, itemHeights]
+  );
+
+  const toggleControls = useCallback(() => {
+    setShowControls((prev) => !prev);
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.headerContainer}>
+        <TouchableOpacity onPress={onBack} style={styles.backButton}>
+          <Text style={styles.backText}>Back</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={toggleControls}>
+          <Text style={styles.backText}>{showControls ? "Hide" : "Show"}</Text>
+        </TouchableOpacity>
+      </View>
+
+      {showControls && (
+        <View style={styles.controlsContainer}>
+          <Text style={styles.sectionLabel}>Columns</Text>
+          <View style={styles.controlsRow}>
+            {[2, 3, 4].map((col) => (
+              <TouchableOpacity
+                key={col}
+                onPress={() => setColumns(col)}
+                style={[styles.chip, columns === col && styles.chipActive]}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    columns === col && styles.chipTextActive,
+                  ]}
+                >
+                  {col}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={styles.sectionLabel}>Actions</Text>
+          <TouchableOpacity onPress={handleAddItem} style={styles.actionButton}>
+            <Text style={styles.actionButtonText}>+ Add Item</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            onPress={handleResetItems}
+            style={[styles.actionButton, styles.secondaryButton]}
+          >
+            <Text style={[styles.actionButtonText, styles.secondaryButtonText]}>
+              Reset
+            </Text>
+          </TouchableOpacity>
+
+          <Text style={styles.statsText}>
+            Items: {items.length} | Columns: {columns}
+          </Text>
+        </View>
+      )}
+
+      <View style={styles.gridWrapper}>
+        <SortableGrid
+          data={normalizedSlots}
+          renderItem={renderItem}
+          dimensions={gridDimensions}
+          orientation={GridOrientation.Vertical}
+          strategy={GridStrategy.Swap}
+          style={styles.grid}
+          contentContainerStyle={styles.gridContent}
+          scrollEnabled={false}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  headerContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingHorizontal: 24,
+    paddingVertical: 20,
+  },
+  headerLeft: {
+    flex: 1,
+  },
+  backButton: {
+    paddingVertical: 8,
+    paddingRight: 12,
+  },
+  backText: {
+    fontSize: 14,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.primary,
+  },
+  headerRight: {
+    flex: 1,
+    alignItems: "flex-end",
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontFamily: fonts.displayBold,
+    color: colors.textPrimary,
+    textAlign: "center",
+  },
+  headerSubtitle: {
+    fontSize: 12,
+    fontFamily: fonts.bodyRegular,
+    color: colors.textMuted,
+    textAlign: "center",
+    marginTop: 4,
+  },
+  controlsContainer: {
+    backgroundColor: colors.surface,
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  sectionLabel: {
+    fontSize: 14,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textSecondary,
+    marginBottom: 8,
+  },
+  controlsRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginBottom: 16,
+  },
+  chip: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+  },
+  chipActive: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primaryMuted,
+  },
+  chipText: {
+    fontSize: 14,
+    fontFamily: fonts.bodySemiBold,
+    color: colors.textSecondary,
+  },
+  chipTextActive: {
+    color: colors.primary,
+  },
+  actionButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    backgroundColor: colors.primary,
+    borderRadius: 8,
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  actionButtonText: {
+    fontSize: 16,
+    fontFamily: fonts.bodySemiBold,
+    color: "#FFFFFF",
+  },
+  secondaryButton: {
+    backgroundColor: colors.surfaceElevated,
+  },
+  secondaryButtonText: {
+    color: colors.textPrimary,
+  },
+  statsText: {
+    fontSize: 14,
+    fontFamily: fonts.bodyRegular,
+    color: colors.textMuted,
+    textAlign: "center",
+    marginTop: 8,
+  },
+  gridWrapper: {
+    flex: 1,
+  },
+  grid: {
+    flex: 1,
+  },
+  gridContent: {
+    padding: 24,
+  },
+  gridItem: {
+    borderRadius: 12,
+    padding: 16,
+    justifyContent: "space-between",
+  },
+  itemHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+  itemTitle: {
+    fontSize: 18,
+    fontFamily: fonts.displayBold,
+    color: "#FFFFFF",
+    flex: 1,
+  },
+  itemSubtitle: {
+    fontSize: 13,
+    fontFamily: fonts.bodyMedium,
+    color: "rgba(255,255,255,0.8)",
+    marginTop: 4,
+  },
+});

--- a/example-app/components/examples/index.ts
+++ b/example-app/components/examples/index.ts
@@ -13,3 +13,4 @@ export { BoundedYAxisExample } from "./BoundedYAxisExample";
 export { CapacityExample } from "./CapacityExample";
 export { CustomDraggableExample } from "./CustomDraggableExample";
 export { DynamicHeightExample } from "./DynamicHeightExample";
+export { DynamicGridExample } from "./DynamicGridExample";

--- a/example-app/navigation/AppNavigator.tsx
+++ b/example-app/navigation/AppNavigator.tsx
@@ -22,6 +22,7 @@ import {
   CapacityExample,
   CustomDraggableExample,
   DynamicHeightExample,
+  DynamicGridExample,
 } from "@/components/examples";
 import { HorizontalSortableExample } from "@/components/HorizontalSortableExample";
 import { GridSortableExample } from "@/components/GridSortableExample";
@@ -47,6 +48,7 @@ export type RootStackParamList = {
   HorizontalSortableExample: undefined;
   GridSortableExample: undefined;
   DynamicHeightExample: undefined;
+  DynamicGridExample: undefined;
 };
 
 const Stack = createStackNavigator<RootStackParamList>();
@@ -172,6 +174,12 @@ function DynamicHeightExampleScreen({
   return <DynamicHeightExample onBack={() => navigation.goBack()} />;
 }
 
+function DynamicGridExampleScreen({
+  navigation,
+}: StackScreenProps<RootStackParamList, "DynamicGridExample">) {
+  return <DynamicGridExample onBack={() => navigation.goBack()} />;
+}
+
 export function AppNavigator() {
   return (
     <NavigationContainer>
@@ -256,6 +264,10 @@ export function AppNavigator() {
         <Stack.Screen
           name="DynamicHeightExample"
           component={DynamicHeightExampleScreen}
+        />
+        <Stack.Screen
+          name="DynamicGridExample"
+          component={DynamicGridExampleScreen}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/hooks/useGridSortable.ts
+++ b/hooks/useGridSortable.ts
@@ -57,6 +57,7 @@ export function useGridSortable<T>(
     onDrop,
     onDragging,
     isBeingRemoved = false,
+    itemIds,
   } = options;
 
   const [isMoving, setIsMoving] = useState(false);
@@ -171,7 +172,9 @@ export function useGridSortable<T>(
         id,
         dimensions,
         orientation,
-        strategy
+        strategy,
+        itemIds,
+        dimensions.itemHeights
       );
       setGridAutoScroll(
         current.x,
@@ -240,7 +243,7 @@ export function useGridSortable<T>(
         scrollDirection !== previousValue
       ) {
         const { width: contentWidth, height: contentHeight } =
-          calculateGridContentDimensions(itemsCount, dimensions, orientation);
+          calculateGridContentDimensions(itemsCount, dimensions, orientation, itemIds, dimensions.itemHeights);
 
         const maxScrollY = Math.max(0, contentHeight - calculatedContainerHeight);
         const maxScrollX = Math.max(0, contentWidth - calculatedContainerWidth);
@@ -375,13 +378,18 @@ export function useGridSortable<T>(
   const animatedStyle = useAnimatedStyle(() => {
     "worklet";
 
+    const itemHeight =
+      itemIds && dimensions.itemHeights
+        ? dimensions.itemHeights[id] || dimensions.itemHeight
+        : dimensions.itemHeight;
+
     if (isBeingRemoved) {
       return {
         position: "absolute",
         top: topValue.value,
         left: leftValue.value,
         width: dimensions.itemWidth,
-        height: dimensions.itemHeight,
+        height: itemHeight,
         zIndex: 0,
         opacity: withTiming(0, { duration: 250 }),
         transform: [{ scale: withTiming(0.5, { duration: 250 }) }],
@@ -393,14 +401,14 @@ export function useGridSortable<T>(
       top: topValue.value,
       left: leftValue.value,
       width: dimensions.itemWidth,
-      height: dimensions.itemHeight,
+      height: itemHeight,
       zIndex: movingSV.value ? 1000 : 0,
       shadowColor: "black",
       shadowOpacity: withSpring(movingSV.value ? 0.2 : 0),
       shadowRadius: 10,
       transform: [{ scale: withSpring(movingSV.value ? 1.05 : 1) }],
     };
-  }, [movingSV, isBeingRemoved, dimensions]);
+  }, [movingSV, isBeingRemoved, dimensions, itemIds, id]);
 
   return {
     animatedStyle,

--- a/hooks/useGridSortableList.ts
+++ b/hooks/useGridSortableList.ts
@@ -55,9 +55,13 @@ export function useGridSortableList<TData extends SortableData>(
     });
   }
 
+  
+  const itemIds = data.map((item) => itemKeyExtractor(item, 0));
+  const itemHeights = dimensions.itemHeights;
+
   // Set up shared values
   const positions = useSharedValue(
-    listToGridObject(data, dimensions, orientation)
+    listToGridObject(data, dimensions, orientation, itemHeights)
   );
   const scrollY = useSharedValue(0);
   const scrollX = useSharedValue(0);
@@ -67,7 +71,7 @@ export function useGridSortableList<TData extends SortableData>(
 
   // Update positions when data or dimensions change
   useEffect(() => {
-    positions.value = listToGridObject(data, dimensions, orientation);
+    positions.value = listToGridObject(data, dimensions, orientation, itemHeights);
   }, [
     data.length,
     data.map((d) => itemKeyExtractor(d, 0)).join(","),
@@ -77,6 +81,7 @@ export function useGridSortableList<TData extends SortableData>(
     dimensions.itemHeight,
     dimensions.rowGap,
     dimensions.columnGap,
+    dimensions.itemHeights,
     orientation,
   ]);
 
@@ -113,7 +118,7 @@ export function useGridSortableList<TData extends SortableData>(
 
   // Calculate content dimensions
   const { width: contentWidth, height: contentHeight } =
-    calculateGridContentDimensions(data.length, dimensions, orientation);
+    calculateGridContentDimensions(data.length, dimensions, orientation, itemIds, itemHeights);
 
   // Helper to get props for each grid item
   const getItemProps = useCallback(
@@ -129,6 +134,7 @@ export function useGridSortableList<TData extends SortableData>(
         dimensions,
         orientation,
         strategy,
+        itemIds,
       };
     },
     [
@@ -141,6 +147,7 @@ export function useGridSortableList<TData extends SortableData>(
       scrollY,
       scrollX,
       autoScrollDirection,
+      itemIds,
     ]
   );
 

--- a/types/grid.ts
+++ b/types/grid.ts
@@ -4,6 +4,7 @@ import { SharedValue } from "react-native-reanimated";
 import { GestureType } from "react-native-gesture-handler";
 import { SortableData } from "./sortable";
 import { DropProviderRef } from "./context";
+import { ItemHeights } from "../utils/gridCalculations";
 
 export enum GridScrollDirection {
   None = "none",
@@ -46,6 +47,8 @@ export interface GridDimensions {
   itemHeight: number;
   rowGap?: number;
   columnGap?: number;
+  /** Optional mapping of item IDs to custom heights */
+  itemHeights?: ItemHeights;
 }
 
 /**
@@ -113,6 +116,9 @@ export interface UseGridSortableOptions<T> {
 
   /** Whether this item is being removed (triggers removal animation) */
   isBeingRemoved?: boolean;
+
+  /** Array of item IDs in the current order (for variable height support) */
+  itemIds?: string[];
 }
 
 /**
@@ -255,6 +261,9 @@ export interface SortableGridItemProps<T> {
   /** Height of the scrollable container */
   containerHeight?: number;
 
+  /** Array of item IDs in the current order (for variable height support) */
+  itemIds?: string[];
+
   /** Delay in ms before drag activates */
   activationDelay?: number;
 
@@ -367,4 +376,7 @@ export interface SortableGridRenderItemProps<TData extends SortableData> {
 
   /** Reordering strategy */
   strategy: GridStrategy;
+
+  /** Array of item IDs in the current order (for variable height support) */
+  itemIds?: string[];
 }

--- a/utils/gridCalculations.ts
+++ b/utils/gridCalculations.ts
@@ -10,12 +10,19 @@ import {
 import { SortableData } from "../types/sortable";
 
 /**
+ * Type for mapping item IDs to their custom heights
+ */
+export type ItemHeights = { [id: string]: number };
+
+/**
  * Calculate grid position from linear index
  */
 export function calculateGridPosition(
   index: number,
   dimensions: GridDimensions,
-  orientation: GridOrientation
+  orientation: GridOrientation,
+  itemIds?: string[],
+  itemHeights?: ItemHeights
 ): GridPosition {
   "worklet";
 
@@ -42,7 +49,25 @@ export function calculateGridPosition(
   }
 
   const x = column * (itemWidth + columnGap);
-  const y = row * (itemHeight + rowGap);
+
+  // Calculate y position with support for variable heights
+  let y: number;
+  if (itemIds && itemHeights && orientation === GridOrientation.Vertical) {
+    y = 0;
+    for (let i = 0; i < index; i++) {
+      const itemRow = Math.floor(i / columns);
+      if (itemRow === row) {
+        // Same row - no contribution to y position
+        break;
+      }
+      const itemId = itemIds[i];
+      const height = itemHeights[itemId] || itemHeight;
+      y += height + rowGap;
+    }
+  } else {
+    // Fixed height calculation
+    y = row * (itemHeight + rowGap);
+  }
 
   return {
     index,
@@ -74,17 +99,31 @@ export function calculateIndexFromRowColumn(
 }
 
 /**
+ * Get the effective height for an item (custom height or default)
+ */
+export function getItemHeight(
+  itemId: string,
+  itemHeight: number,
+  itemHeights?: ItemHeights
+): number {
+  "worklet";
+  return itemHeights?.[itemId] || itemHeight;
+}
+
+/**
  * Convert data array to grid positions object
  */
 export function listToGridObject<T extends SortableData>(
   list: T[],
   dimensions: GridDimensions,
-  orientation: GridOrientation
+  orientation: GridOrientation,
+  itemHeights?: ItemHeights
 ): GridPositions {
   const positions: GridPositions = {};
+  const itemIds = list.map((item) => item.id);
 
   for (let i = 0; i < list.length; i++) {
-    const position = calculateGridPosition(i, dimensions, orientation);
+    const position = calculateGridPosition(i, dimensions, orientation, itemIds, itemHeights);
     positions[list[i].id] = position;
   }
 
@@ -151,7 +190,9 @@ export function reorderGridInsert(
   activeId: string,
   targetIndex: number,
   dimensions: GridDimensions,
-  orientation: GridOrientation
+  orientation: GridOrientation,
+  itemIds?: string[],
+  itemHeights?: ItemHeights
 ): GridPositions {
   "worklet";
 
@@ -174,21 +215,27 @@ export function reorderGridInsert(
       newPositions[id] = calculateGridPosition(
         targetIndex,
         dimensions,
-        orientation
+        orientation,
+        itemIds,
+        itemHeights
       );
     } else if (movingUp && currentIndex >= targetIndex && currentIndex < fromIndex) {
       // Shift items down (increase index by 1)
       newPositions[id] = calculateGridPosition(
         currentIndex + 1,
         dimensions,
-        orientation
+        orientation,
+        itemIds,
+        itemHeights
       );
     } else if (!movingUp && currentIndex <= targetIndex && currentIndex > fromIndex) {
       // Shift items up (decrease index by 1)
       newPositions[id] = calculateGridPosition(
         currentIndex - 1,
         dimensions,
-        orientation
+        orientation,
+        itemIds,
+        itemHeights
       );
     } else {
       // Keep the same position
@@ -236,7 +283,9 @@ export function setGridPosition(
   id: string,
   dimensions: GridDimensions,
   orientation: GridOrientation,
-  strategy: GridStrategy
+  strategy: GridStrategy,
+  itemIds?: string[],
+  itemHeights?: ItemHeights
 ): void {
   "worklet";
 
@@ -275,7 +324,9 @@ export function setGridPosition(
       id,
       targetCell.index,
       dimensions,
-      orientation
+      orientation,
+      itemIds,
+      itemHeights
     );
   } else if (strategy === GridStrategy.Swap && targetId) {
     positions.value = reorderGridSwap(
@@ -294,7 +345,9 @@ export function setGridPosition(
 export function calculateGridContentDimensions(
   itemsCount: number,
   dimensions: GridDimensions,
-  orientation: GridOrientation
+  orientation: GridOrientation,
+  itemIds?: string[],
+  itemHeights?: ItemHeights
 ): { width: number; height: number } {
   "worklet";
 
@@ -308,10 +361,26 @@ export function calculateGridContentDimensions(
   } = dimensions;
 
   if (orientation === GridOrientation.Vertical) {
-    // Calculate number of rows needed
-    const totalRows = Math.ceil(itemsCount / columns);
     const width = columns * itemWidth + (columns - 1) * columnGap;
-    const height = totalRows * itemHeight + (totalRows - 1) * rowGap;
+
+    // Calculate height with support for variable heights
+    let height: number;
+    if (itemIds && itemHeights) {
+      height = 0;
+      for (let i = 0; i < itemsCount; i++) {
+        const itemId = itemIds[i];
+        const itemHeightValue = itemHeights[itemId] || itemHeight;
+        height += itemHeightValue;
+        if (i < itemsCount - 1) {
+          height += rowGap;
+        }
+      }
+    } else {
+      // Fixed height calculation
+      const totalRows = Math.ceil(itemsCount / columns);
+      height = totalRows * itemHeight + (totalRows - 1) * rowGap;
+    }
+
     return { width, height };
   } else {
     // Calculate number of columns needed


### PR DESCRIPTION


https://github.com/user-attachments/assets/5aa93fe8-f754-4d65-b9d6-8808fcd383c6

- Add itemHeights parameter to GridDimensions for per-item height customization
- Modify grid calculations (calculateGridPosition, calculateGridContentDimensions, etc.) to support variable heights
- Update useGridSortable and useGridSortableList hooks to handle itemIds and itemHeights
- Extend SortableGridItemProps and SortableGridRenderItemProps types with itemIds parameter
- Update SortableGridItem component to pass itemIds to hooks
- Add DynamicGridExample demonstrating items with different heights (tall/short variations)
- Include visual indicators (TALL/SHORT labels) to showcase height differences

Feature Request: Allow grid items to have variable heights for masonry-style layouts