### PR TITLE
Add preDragDelay option to Sortable / SortableItem (matches Draggable API)

### DIFF
--- a/components/SortableItem.tsx
+++ b/components/SortableItem.tsx
@@ -95,6 +95,7 @@ function VerticalSortableItemInner<T>({
   onDragStart,
   onDrop,
   onDragging,
+  preDragDelay,
 }: VerticalSortableItemInnerProps<T>) {
   const { animatedStyle, panGestureHandler, handlePanGestureHandler, registerHandle } = useSortable<T>({
     id,
@@ -111,6 +112,7 @@ function VerticalSortableItemInner<T>({
     onDragStart,
     onDrop,
     onDragging,
+    preDragDelay,
   });
 
   // Handle layout measurement for dynamic heights
@@ -160,6 +162,7 @@ function HorizontalSortableItemInner<T>({
   onDragStart,
   onDrop,
   onDraggingHorizontal,
+  preDragDelay,
 }: HorizontalSortableItemInnerProps<T>) {
   const { animatedStyle, panGestureHandler, handlePanGestureHandler, registerHandle } =
     useHorizontalSortable<T>({
@@ -176,6 +179,7 @@ function HorizontalSortableItemInner<T>({
       onDragStart,
       onDrop,
       onDragging: onDraggingHorizontal,
+      preDragDelay,
     });
 
   return renderSortableContent(

--- a/hooks/useHorizontalSortable.ts
+++ b/hooks/useHorizontalSortable.ts
@@ -152,6 +152,7 @@ export function useHorizontalSortable<T>(
     onDragStart,
     onDrop,
     onDragging,
+    preDragDelay = 200,
   } = options;
 
   const [isMoving, setIsMoving] = useState(false);
@@ -347,7 +348,7 @@ export function useHorizontalSortable<T>(
 
   const createPanGesture = () =>
     Gesture.Pan()
-      .activateAfterLongPress(200)
+      .activateAfterLongPress(preDragDelay)
       .shouldCancelWhenOutside(false)
       .onStart((event) => {
         "worklet";

--- a/hooks/useSortable.ts
+++ b/hooks/useSortable.ts
@@ -137,6 +137,13 @@ export interface UseSortableOptions<T> {
     overItemId: string | null,
     yPosition: number
   ) => void;
+  /**
+   * Long-press duration in milliseconds before the drag gesture activates.
+   * Pass `0` for immediate activation when using a dedicated drag handle.
+   *
+   * @default 200
+   */
+  preDragDelay?: number;
 }
 
 export interface UseSortableReturn {
@@ -182,6 +189,7 @@ export function useSortable<T>(
     onDragStart,
     onDrop,
     onDragging,
+    preDragDelay = 200,
   } = options;
 
   // Effective item height for fixed mode calculations
@@ -420,7 +428,7 @@ export function useSortable<T>(
   // === Pan gesture ===
   const createPanGesture = () =>
     Gesture.Pan()
-      .activateAfterLongPress(200)
+      .activateAfterLongPress(preDragDelay)
       .shouldCancelWhenOutside(false)
       .onStart((event) => {
         "worklet";

--- a/types/sortable.ts
+++ b/types/sortable.ts
@@ -219,6 +219,22 @@ export interface UseSortableOptions<T> {
     overItemId: string | null,
     yPosition: number
   ) => void;
+
+  /**
+   * Long-press duration in milliseconds before the drag gesture activates.
+   * Pass `0` for immediate activation (typical when using a dedicated drag
+   * handle, where the touch target already disambiguates intent from
+   * scroll/tap).
+   *
+   * @default 200
+   *
+   * @example
+   * ```typescript
+   * // Dedicated handle: drag begins as soon as the user touches it.
+   * useSortable({ id, positions, ..., preDragDelay: 0 });
+   * ```
+   */
+  preDragDelay?: number;
 }
 
 /**
@@ -571,6 +587,14 @@ export interface SortableItemProps<T> {
     overItemId: string | null,
     xPosition: number
   ) => void;
+
+  /**
+   * Long-press duration in milliseconds before the drag gesture activates.
+   * Pass `0` for immediate activation when using a dedicated drag handle.
+   *
+   * @default 200
+   */
+  preDragDelay?: number;
 }
 
 /**
@@ -804,6 +828,14 @@ export interface UseHorizontalSortableOptions<T> {
     overItemId: string | null,
     xPosition: number
   ) => void;
+
+  /**
+   * Long-press duration in milliseconds before the drag gesture activates.
+   * Pass `0` for immediate activation when using a dedicated drag handle.
+   *
+   * @default 200
+   */
+  preDragDelay?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

`useDraggable` already exposes a `preDragDelay` prop (default `0`) so callers can decide whether the drag gesture activates immediately or only after a long-press. The Sortable side does not have an equivalent: `useSortable` and `useHorizontalSortable` both build their pan gesture with a hardcoded `activateAfterLongPress(200)`. That is a reasonable default for bare list rows (it disambiguates drag from list scroll), but it is the wrong default when the consumer uses a dedicated drag handle. In that case the touch target already encodes intent, and the 200ms wait reads as the row being unresponsive.

This PR makes the long-press duration configurable on the Sortable side, using the same option name and shape as `useDraggable` so the API stays consistent across the library. The default stays at `200`, so existing consumers see no behavior change.

## Changes

- `hooks/useSortable.ts`: adds `preDragDelay` (default `200`) to `UseSortableOptions` and forwards it into `activateAfterLongPress`.
- `hooks/useHorizontalSortable.ts`: same treatment.
- `components/SortableItem.tsx`: threads `preDragDelay` through `VerticalSortableItemInner` and `HorizontalSortableItemInner` into the hook calls.
- `types/sortable.ts`: documents `preDragDelay` on `UseSortableOptions`, `UseHorizontalSortableOptions`, and `SortableItemProps` with TSDoc consistent with the surrounding style.

No runtime behavior change unless the consumer opts in.

## Usage

```tsx
// Dedicated handle: drag begins on touch, no 200ms wait
<SortableItem
  id={id}
  positions={positions}
  lowerBound={lowerBound}
  autoScrollDirection={autoScrollDirection}
  itemsCount={itemsCount}
  itemHeight={64}
  preDragDelay={0}
>
  <Row>
    <SortableItem.Handle><Grip /></SortableItem.Handle>
    <RowContent />
  </Row>
</SortableItem>
```

```tsx
// useSortable directly
const { animatedStyle, panGestureHandler } = useSortable({
  id, positions, lowerBound, autoScrollDirection, itemsCount, itemHeight,
  preDragDelay: 0,
});
```

## Notes

- Naming matches `useDraggable.preDragDelay` rather than `useGridSortable.activationDelay` (the grid hook predates this and uses a different name; happy to follow up with an alias / rename if desired, but kept it out of this PR to keep the diff focused on the missing capability rather than churning a working API).
- TypeScript: `tsc --noEmit` passes against the existing `tsconfig.json` after the changes.

## Test plan

- [ ] Existing example app still works with default behavior (no `preDragDelay` passed).
- [ ] Vertical sortable with `preDragDelay={0}` initiates drag without a long-press wait.
- [ ] Horizontal sortable with `preDragDelay={0}` behaves the same.
- [ ] Passing a custom value (e.g. `preDragDelay={500}`) honors it.