### PR TITLE
fix(Sortable): preserve native scroll momentum (don't cancel deceleration on every scroll frame)

### DIFF
--- a/hooks/useSortableList.ts
+++ b/hooks/useSortableList.ts
@@ -208,16 +208,32 @@ export function useSortableList<TData extends { id: string }>(
     [data, itemKeyExtractor, estimatedItemHeight, onHeightsMeasured]
   );
 
-  // Scrolling synchronization
+  // Mirror of the user-driven scroll position. Used to discriminate
+  // user-driven scrollY updates from auto-scroll worklet updates so the
+  // reaction below doesn't cancel native momentum on every scroll frame.
+  const userScrollY = useSharedValue(0);
+
+  // Scrolling synchronization. The reaction propagates auto-scroll commands
+  // (drag-near-edge) to the actual scroll view via scrollTo. It must skip
+  // user-driven updates: scrollTo with animated:false maps to
+  // setContentOffset:animated:NO on iOS (and the equivalent on Android),
+  // which cancels active deceleration. Calling it on every frame of momentum
+  // scroll kills inertia and the list stops dead the moment the user lifts
+  // their finger. We detect user-driven updates by checking userScrollY,
+  // which handleScroll keeps in sync with the actual contentOffset.
   useAnimatedReaction(
     () => scrollY.value,
     (scrolling) => {
+      if (scrolling === userScrollY.value) return;
       scrollTo(scrollViewRef, 0, scrolling, false);
     }
   );
 
-  // Handle scroll events
+  // Handle scroll events. userScrollY is written BEFORE scrollY so that when
+  // the reaction above fires (triggered by the scrollY change), userScrollY
+  // is already at the new value and the equality check short-circuits.
   const handleScroll = useAnimatedScrollHandler((event) => {
+    userScrollY.value = event.contentOffset.y;
     scrollY.value = event.contentOffset.y;
   });
 


### PR DESCRIPTION
## Problem

Lists rendered with `<Sortable>` have no inertial scrolling. The user flicks to scroll, releases their finger, and the list stops dead the same frame their finger lifts. Native iOS / Android momentum deceleration is cancelled.

## Cause

`useSortableList` uses one `useSharedValue` (`scrollY`) for two semantically different things:

1. The auto-scroll-during-drag feature writes to `scrollY` to programmatically nudge the list when the user drags an item near the screen edge. A `useAnimatedReaction` then propagates that desired position to the actual scroll view via `scrollTo(scrollViewRef, 0, scrolling, false)`.
2. The user's native scroll also writes to `scrollY` via `useAnimatedScrollHandler` (so the drag system knows where the viewport is).

The reaction can't tell which source updated `scrollY`, so it fires for both. During native momentum scroll:

1. User flicks and releases.
2. Native UIScrollView starts decelerating; each frame, `contentOffset.y` increments.
3. `handleScroll` fires, `scrollY.value` updates.
4. `useAnimatedReaction` fires, calls `scrollTo(animated: false)`.
5. iOS `setContentOffset:animated:NO` (and the Android equivalent) cancels active deceleration.
6. Scroll engine has no momentum left, list stops dead.

## Fix

Discriminate user-driven from auto-scroll-driven `scrollY` updates with a second shared value, `userScrollY`. `handleScroll` writes both `userScrollY` and `scrollY` to the same value. The reaction skips `scrollTo` when the new `scrollY` matches `userScrollY` because that means the change came from the user, not from the auto-scroll worklet.

```ts
const userScrollY = useSharedValue(0);

useAnimatedReaction(
  () => scrollY.value,
  (scrolling) => {
    if (scrolling === userScrollY.value) return;
    scrollTo(scrollViewRef, 0, scrolling, false);
  },
);

const handleScroll = useAnimatedScrollHandler((event) => {
  userScrollY.value = event.contentOffset.y;
  scrollY.value = event.contentOffset.y;
});
```

`handleScroll` writes `userScrollY` *before* `scrollY` so that when the reaction fires (triggered by the `scrollY` change), `userScrollY` is already at the new value and the equality check short-circuits. Auto-scroll worklets that touch `scrollY` directly leave `userScrollY` untouched, the values diverge, and the reaction propagates as before.

## Behavior

* Inertial scrolling restored on every `<Sortable>` list (iOS and Android).
* Auto-scroll-during-drag continues to work unchanged.
* No public API changes.

## Verification

Tested locally on iOS and Android with a 30+ item list:

* Before: flick to scroll, list stops the moment the finger lifts.
* After: native deceleration plays out smoothly.
* Drag-near-edge auto-scroll still nudges the list as before.
