### PR TITLE
fix(Sortable): preserve scroll position across reorders (don't remount on every drop)

### DIFF
--- a/components/sortableUtils.ts
+++ b/components/sortableUtils.ts
@@ -295,12 +295,26 @@ export function getItemCumulativeY(
 }
 
 /**
- * Returns a hash code based on the data
+ * Returns a hash code based on which items are in the list.
+ *
+ * Sortable wraps SortableComponent with `key={dataHash(data)}` to force a
+ * remount whenever the hash changes. We hash on item membership (count + the
+ * sorted set of ids), not on item order, so reorders DON'T trigger a
+ * remount. Reorders are handled by syncing the `positions` shared value in
+ * useSortableList — the visual reorder still happens, but without unmounting
+ * the FlatList and resetting its scroll position to 0.
+ *
+ * Add / remove still changes the hash (new id concatenation) and still
+ * triggers the remount, which is correct: those need positions to be
+ * reinitialized from the new data with the new item count.
+ *
  * @param  {any[]} data The data to hash.
  * @return {string}    A 32bit integer
  */
 export const dataHash = (data: any[]): string => {
-  const str = data.reduce((acc, item) => acc + item.id, "");
+  const ids = data.map((item) => item.id);
+  ids.sort();
+  const str = ids.join("");
   let hash = 0;
   for (let i = 0, len = str.length; i < len; i++) {
     let chr = str.charCodeAt(i);

--- a/hooks/useSortableList.ts
+++ b/hooks/useSortableList.ts
@@ -122,6 +122,18 @@ export function useSortableList<TData extends { id: string }>(
   const scrollViewRef = useAnimatedRef();
   const dropProviderRef = useRef<DropProviderRef | null>(null);
 
+  // Sync positions when data order changes without remount. The Sortable
+  // wrapper now hashes on item membership (not order), so reorders don't
+  // trigger the key-change remount that would reset scroll position. We
+  // re-derive `positions` here so the visual order matches the new data
+  // prop. Add / remove cases still hit the hash-change remount path and
+  // re-initialize positions through useSharedValue's initial value, so this
+  // effect is a no-op in those cases (same id set produces equal mapping).
+  useEffect(() => {
+    positions.value = listToObject(data);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
   // Dynamic height shared values — initialized with estimated heights
   // so items are positioned correctly from the first frame.
   const initialHeights = useMemo(() => {


### PR DESCRIPTION
## Problem

`<Sortable>` resets the FlatList scroll position to 0 every time the user reorders an item. On long lists this is painful: drag a row, drop it, the list snaps back to the top and the user loses their place. Especially bad when the row was visible mid-scroll, because the user's entire scroll context disappears.

## Cause

`Sortable.tsx` wraps `SortableComponent` with `key={dataHash(data)}` to force a remount whenever the hash changes:

```ts
export const Sortable = memo(({ data, renderItem, ...props }) => {
  const dataHashKey = dataHash(data);
  return <SortableComponent data={data} renderItem={renderItem} {...props} key={dataHashKey} />;
});
```

The original `dataHash` concatenates ids in array order:

```ts
const str = data.reduce((acc, item) => acc + item.id, "");
```

So any reorder produces a new hash. The key changes, React unmounts and remounts `SortableComponent`, and the underlying FlatList's scroll position resets to 0.

The remount is used as a way to keep the internal `positions` shared value in sync with the data prop, because `useSharedValue` only consumes its initial value once:

```ts
const positions = useSharedValue(listToObject(data));   // only on mount
```

If `data` changed without remount, `positions` would stay stale relative to the new data order.

## Fix

Two coordinated changes:

1. Hash on item *membership* (count + sorted ids), not on order. Reorders don't change the hash, so the key doesn't change, so there's no remount.

2. Add a `useEffect` in `useSortableList` that re-derives `positions` from the current data whenever `data` changes. This keeps the internal state in sync without needing a remount.

```ts
// components/sortableUtils.ts
export const dataHash = (data: any[]): string => {
  const ids = data.map((item) => item.id);
  ids.sort();
  const str = ids.join("");
  let hash = 0;
  for (let i = 0, len = str.length; i < len; i++) {
    let chr = str.charCodeAt(i);
    hash = (hash << 5) - hash + chr;
    hash |= 0;
  }
  return hash.toString();
};

// hooks/useSortableList.ts
useEffect(() => {
  positions.value = listToObject(data);
}, [data]);
```

Add and remove still change the hash (new id set, different concatenation), so they still trigger the remount path. That's correct: those cases genuinely need positions to be reinitialized from the new data with a new item count, and the remount also resets the FlatList virtualization correctly for the new size.

Reorders skip the remount. The `useEffect` updates `positions`, items animate to their new slots, and scroll position is preserved.

## Behavior

* Reorders preserve scroll position on iOS and Android.
* Add and remove still trigger the existing remount path (no behavior change for those).
* Auto-scroll-during-drag, drop callbacks, and every other public API are unchanged.
* No public API changes; this is a pure internal refactor.

## Verification

Tested locally on iOS and Android with a 30+ item list:

* Before: drag any row, drop, list jumps to top.
* After: drag any row, drop, scroll position is preserved exactly.
* Add / remove animations and scroll behavior unchanged from current.
* Drag-near-edge auto-scroll still nudges the list as before.
